### PR TITLE
Add consolidated health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@ Environment variables expected by the services include:
 
 - `PROPERTY_URL` – URL for the Property service used by the gateway
 - `MARTECH_URL` – URL for the Martech service used by the gateway
+- `INSIGHT_AGENT_URL` – URL for the Insight Agent service used by the gateway
+- `BROWSE_RUNNER_URL` – URL for the Browse Runner service used by the gateway
 - `N8N_URL` – base URL for the n8n instance
 - `N8N_WORKFLOW_ID` – ID of the workflow to execute (default `1`)
 - `OPENAI_API_KEY` – API key for the Insight Agent service
 - `PORT` – port the service listens on (set automatically by Railway)
 - `PGUSER`, `PGPASSWORD`, `PGDATABASE`, `PGHOST` – optional database settings
 - `RAILWAY_ENVIRONMENT` – automatically provided during deploy but unused by the Dockerfiles
+
+The gateway's `/health` endpoint checks each service listed above and returns a consolidated status.
 
 ## Quick Start (Local)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     environment:
       PROPERTY_URL: http://property:80
       MARTECH_URL: http://martech:80
+      INSIGHT_AGENT_URL: http://insight-agent:80
+      BROWSE_RUNNER_URL: http://browse-runner:80
       N8N_URL: http://n8n:5678
     ports:
       - "8000:80"


### PR DESCRIPTION
## Summary
- expand environment variables used by gateway
- implement aggregated `/health` endpoint in gateway
- document new environment variables in README
- set service URLs in docker-compose
- update gateway health test

## Testing
- `docker-compose build` *(fails: Docker daemon not running)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879ecc70ac88329be6629f1d0f143cb