### PR TITLE
Add property docker build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,7 @@ jobs:
       - run: poetry run bash -c 'PYTHONPATH=src:services pytest -q'
       - name: Build interface image
         run: docker build -t interface-image ./interface
+      - name: Build property image
+        run: docker build -t property-image -f services/property/Dockerfile .
       - name: Verify npx exists
         run: docker run --rm interface-image which npx


### PR DESCRIPTION
## Summary
- ensure property Dockerfile builds in CI by adding a `docker build` step

## Testing
- `poetry run bash -c 'PYTHONPATH=src:services pytest -q'`

------
https://chatgpt.com/codex/tasks/task_e_68826c913c1483299ac4c9330c93bd97