### PR TITLE
Add SERVICE_PATH build arg for property service

### DIFF
--- a/services/property/Dockerfile
+++ b/services/property/Dockerfile
@@ -3,12 +3,13 @@ FROM python:3.11-slim
 ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1
 ENV PORT=8000
 
+ARG SERVICE_PATH=services/property
+
 WORKDIR /app
 
 # This Dockerfile expects the repository root as the build context.
-# If you build from `services/property`, remove the `services/property/` prefix
-# from COPY instructions.
-COPY services/property/requirements.txt ./requirements.txt
+# Set the SERVICE_PATH build arg to '.' when building from `services/property`.
+COPY ${SERVICE_PATH}/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy source after installing dependencies

--- a/services/property/README.md
+++ b/services/property/README.md
@@ -17,10 +17,15 @@ curl -X POST http://localhost:8082/analyze \
 
 Run this service locally via Docker Compose or by setting `SERVICE=property` and executing `uvicorn app:app`.
 
-The `Dockerfile` in this directory assumes the build context is the repository root.
-This lets paths such as `services/property/requirements.txt` resolve correctly.
-If you instead set the context to `services/property`, remove the `services/property/` prefix from the `COPY` instructions.
-Railway builds this service from the repository root (`projectPath = "."` in `railway.toml`), so the existing `COPY` paths are valid.
+The `Dockerfile` works with either the repository root or `services/property` as the build context.
+It defines a `SERVICE_PATH` build argument (default `services/property`) used in `COPY` instructions.
+When building from within `services/property`, override this argument:
+
+```bash
+docker build --build-arg SERVICE_PATH=. .
+```
+
+Railway builds this service from the repository root (`projectPath = "."` in `railway.toml`), so no override is needed there.
 
 The gateway aggregates this DNS check with martech analysis. Send
 `POST /analyze` to the gateway with `{ "url": "https://example.com" }`


### PR DESCRIPTION
## Summary
- support flexible build context via `SERVICE_PATH` arg in `services/property/Dockerfile`
- document overriding `SERVICE_PATH` when building from `services/property`

## Testing
- `PYTHONPATH=src:services:. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826f988f84832993b38d127d9eefdd