### PR TITLE
Fix property PYTHONPATH

### DIFF
--- a/services/property/Dockerfile
+++ b/services/property/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy source after installing dependencies
 COPY . /app
-ENV PYTHONPATH=/app
+ENV PYTHONPATH=/app/src:/app/services:/app
 
 EXPOSE 8000
 HEALTHCHECK --interval=2s --timeout=2s --start-period=5s \


### PR DESCRIPTION
## Summary
- ensure property service can import gateway modules by updating `PYTHONPATH`

## Testing
- `make lint`
- `make test`
- `PYTHONPATH=src:services:. SERVICE=property uvicorn app:app --port 8000` (manual check)


------
https://chatgpt.com/codex/tasks/task_e_688280a480b88329a2a77bd984895562