### PR TITLE
Update railway build args

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -2,7 +2,7 @@ schema = "https://railway.com/railway.schema.json"
 
 [build]
 builder = "DOCKERFILE"
-dockerfilePath = "services/property/Dockerfile"
+dockerfilePath = "services/python.Dockerfile"
 
 [deploy]
 healthcheckPath     = "/health"
@@ -12,22 +12,30 @@ healthcheckInterval = 2000
 [[services]]
 name         = "gateway"
 projectPath  = "."
-startCommand = "sh -c \"uvicorn services.gateway.app:app --host 0.0.0.0 --port ${PORT:-8000}\""
 instances    = 1
+healthcheckPath = "/health"
+[services.buildArgs]
+SERVICE = "gateway"
 
 [[services]]
 name         = "martech"
 projectPath  = "."
-startCommand = "sh -c \"uvicorn services.martech.app:app --host 0.0.0.0 --port ${PORT:-8000}\""
 instances    = 1
+healthcheckPath = "/health"
+[services.buildArgs]
+SERVICE = "martech"
 
 [[services]]
 name           = "property"
 instances      = 1
 projectPath    = "."
+healthcheckPath = "/health"
+[services.buildArgs]
+SERVICE = "property"
 
 [[services]]
 name         = "interface"
 projectPath  = "interface"
 startCommand = "npm start"
 instances    = 1
+healthcheckPath = "/health"


### PR DESCRIPTION
## Summary
- use `services/python.Dockerfile` for Railway builds
- specify `buildArgs` and health checks per service
- defer to Dockerfile `CMD` for Python service startup

## Testing
- `tox -e py`

------
https://chatgpt.com/codex/tasks/task_e_6882a17a5c188329906281c0d563e85d