### PR TITLE
Fix paths after services move

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
           python-version: "3.11"
       - run: pip install poetry
       - run: poetry install --only main
-      - run: poetry run bash -c 'PYTHONPATH=src:services pytest -q'
+      - run: poetry run bash -c 'PYTHONPATH=services pytest -q'
       - name: Build interface image
         run: docker build -t interface-image ./interface
       - name: Build property image

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY src/ /app/src
 COPY services/ /app/services
 COPY fingerprints.yaml /app/
-ENV PYTHONPATH=/app/src:/app/services:/app
+ENV PYTHONPATH=/app/services:/app
 
 # Expose port
 EXPOSE 8000

--- a/services/property/Dockerfile
+++ b/services/property/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy source after installing dependencies
 COPY . /app
-ENV PYTHONPATH=/app/src:/app/services:/app
+ENV PYTHONPATH=/app/services:/app
 
 EXPOSE 8000
 HEALTHCHECK --interval=2s --timeout=2s --start-period=5s \

--- a/tests/test_app_service.py
+++ b/tests/test_app_service.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 from services.gateway.app import app as gateway_app
 from services.martech.app import app as martech_app
-from property.app import app as property_app
+from services.property.app import app as property_app
 
 
 def test_load_gateway():

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from property.app import app
+from services.property.app import app
 
 client = TestClient(app)
 

--- a/tests/test_ready.py
+++ b/tests/test_ready.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from property.app import app
+from services.property.app import app
 
 client = TestClient(app)
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py,lint,type
 skipsdist = True
 
 [testenv]
-setenv = PYTHONPATH = {toxinidir}/src:{toxinidir}/services:{toxinidir}
+setenv = PYTHONPATH = {toxinidir}/services:{toxinidir}
 deps =
     pytest
     httpx
@@ -15,9 +15,9 @@ commands = pytest
 [testenv:lint]
 basepython = python3
 deps = flake8
-commands = flake8 src services tests
+commands = flake8 services tests
 
 [testenv:type]
 basepython = python3
 deps = mypy
-commands = mypy --ignore-missing-imports src services
+commands = mypy --ignore-missing-imports services


### PR DESCRIPTION
## Summary
- update tests to import from `services.property`
- remove `src/` from tox env vars and checks
- update docker and ci PYTHONPATH to point at `services`

## Testing
- `tox -e py`

------
https://chatgpt.com/codex/tasks/task_e_6882a3ddeebc8329b77e03f1748b7d49