### PR TITLE
Update service build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,14 @@ docker compose up --build
 # martech -> http://localhost:8081
 # property -> http://localhost:8082
 open http://localhost:8080/docs
-# SERVICE env var selects gateway (default), martech, or property
+# Compose passes `SERVICE` so `services/python.Dockerfile` starts the correct FastAPI app
 # MARTECH_URL and PROPERTY_URL control where the gateway proxies requests
 ```
+
+All Python APIs build from `services/python.Dockerfile`. The `SERVICE` build
+argument selects which module to run, and the healthcheck hits `/health` by
+default. Docker Compose passes this argument automatically for each service.
+
 To launch the web interface during development:
 ```bash
 cd interface && npm install && VITE_API_BASE_URL=http://localhost:8080 npm run dev

--- a/services/property/README.md
+++ b/services/property/README.md
@@ -17,10 +17,10 @@ curl -X POST http://localhost:8082/analyze \
 
 Run this service locally via Docker Compose or by executing `uvicorn property.app:app`.
 
-The `Dockerfile` expects the repository root as the build context. It copies the shared
-`requirements.txt` before installing dependencies and then adds the service code.
-Railway builds this service from the repository root (`projectPath = "."` in `railway.toml`),
-so no special build arguments are needed.
+All Python APIs build from `services/python.Dockerfile` with the repository root as the
+context. Set the `SERVICE` build argument to `property` (Docker Compose handles this) and
+the container will start `services.property.app`. The Dockerfile defines a healthcheck that
+queries `/health` by default.
 
 The gateway aggregates this DNS check with martech analysis. Send
 `POST /analyze` to the gateway with `{ "url": "https://example.com" }`


### PR DESCRIPTION
## Summary
- document python.Dockerfile for all services
- clarify the SERVICE build argument and healthcheck path
- drop notes about the old root dispatcher

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6882a552e6e48329a3d9a5dfd2ee589f