### PR TITLE
Update Dockerfile references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ docker compose up --build
 # martech -> http://localhost:8081
 # property -> http://localhost:8082
 open http://localhost:8080/docs
-# Compose passes `SERVICE` so `services/python.Dockerfile` starts the correct FastAPI app
+# Compose passes `SERVICE` so the root `Dockerfile` starts the correct FastAPI app
 # MARTECH_URL and PROPERTY_URL control where the gateway proxies requests
 ```
 
-All Python APIs build from `services/python.Dockerfile`. The `SERVICE` build
+All Python APIs build from the repository root `Dockerfile`. The `SERVICE` build
 argument selects which module to run, and the healthcheck hits `/health` by
 default. Docker Compose passes this argument automatically for each service.
 

--- a/services/property/README.md
+++ b/services/property/README.md
@@ -17,9 +17,9 @@ curl -X POST http://localhost:8082/analyze \
 
 Run this service locally via Docker Compose or by executing `uvicorn property.app:app`.
 
-All Python APIs build from `services/python.Dockerfile` with the repository root as the
-context. Set the `SERVICE` build argument to `property` (Docker Compose handles this) and
-the container will start `services.property.app`. The Dockerfile defines a healthcheck that
+All Python APIs build from the repository root `Dockerfile`. Set the `SERVICE` build argument
+to `property` (Docker Compose handles this) and the container will start `services.property.app`.
+The Dockerfile defines a healthcheck that
 queries `/health` by default.
 
 The gateway aggregates this DNS check with martech analysis. Send


### PR DESCRIPTION
## Summary
- fix docs to mention root Dockerfile instead of services/python.Dockerfile
- keep instructions on using the SERVICE build argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882cf81aca48329a0a0a7a9483e7591