### PR TITLE
Add pytest.ini for direct pytest runs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -q
+env =
+    PYTHONPATH = {toxinidir}/services:{toxinidir}


### PR DESCRIPTION
## Summary
- configure pytest env vars so tests can run without tox

## Testing
- `PYTHONPATH=services:. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e4b1b41c832998c39bc31151c5ff