### PR TITLE
Update property README command

### DIFF
--- a/services/property/README.md
+++ b/services/property/README.md
@@ -15,7 +15,7 @@ curl -X POST http://localhost:8082/analyze \
   -d '{"domain": "example.com"}'
 ```
 
-Run this service locally via Docker Compose or by executing `uvicorn property.app:app`.
+Run this service locally via Docker Compose or by executing `uvicorn services.property.app:app`.
 
 All Python APIs build from the `Dockerfile` at the repository root with the
 repository root as the context. Set the `SERVICE` build argument to `property`


### PR DESCRIPTION
## Summary
- fix the example `uvicorn` command in `services/property/README.md` to match the service path

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6882ef510b948329b533914b27ba9872