### PR TITLE
Update uvicorn entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ COPY . /app
 ENV PYTHONPATH=/app/services:/app
 EXPOSE 8000
 HEALTHCHECK CMD curl -fsS http://127.0.0.1:8000/health || exit 1
-CMD ["sh", "-c", "uvicorn services.${SERVICE:-gateway}.app:app --host 0.0.0.0 --port ${PORT:-8000}"]
+# Each service exposes its own FastAPI app under `services/<name>/app.py`.
+# The `SERVICE` environment variable selects which module Uvicorn runs.
+CMD ["sh", "-c", "uvicorn services.${SERVICE}.app:app --host 0.0.0.0 --port ${PORT:-8000}"]


### PR DESCRIPTION
## Summary
- run uvicorn using the `SERVICE` env var

## Testing
- `PYTHONPATH=$(pwd)/services:$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f59267e48329a9b95aacd73aabe7