### PR TITLE
Unify python service startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,6 @@ Unitron automatically reverse-engineers a prospect’s website, generates synthe
 - Generate persona summaries and demo flows via LLM prompts.
 
 ### Build stability philosophy
-We believe reliability starts with deterministic builds. A single Dockerfile at the repo root installs dependencies from `pyproject.toml` using Poetry with no network calls after the initial dependency fetch. Health checks ensure that Railway deploys never wait more than a few seconds for readiness.
+We believe reliability starts with deterministic builds. A single Dockerfile (`docker/python.Dockerfile`) installs dependencies from `pyproject.toml` using Poetry with no network calls after the initial dependency fetch. Health checks ensure that Railway deploys never wait more than a few seconds for readiness. Uvicorn is launched via `ops/entrypoint.sh` which validates imports before starting the selected service.
 
 Developers are encouraged to extend the services but should preserve the quick startup time and the clean separation between gateway orchestration and martech analysis logic. Unit tests in `tests/` serve as living documentation and prevent regressions.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ docker compose up --build
 # martech -> http://localhost:8081
 # property -> http://localhost:8082
 open http://localhost:8080/docs
-# Compose passes `SERVICE` so the root `Dockerfile` starts the correct FastAPI app
+# Compose passes `SERVICE` so `docker/python.Dockerfile` starts the correct FastAPI app
 # MARTECH_URL and PROPERTY_URL control where the gateway proxies requests
 ```
 
-All Python APIs build from the `Dockerfile` at the repository root. The
-`SERVICE` build argument selects which module to run, and the healthcheck hits
-`/health` by default. Docker Compose passes this argument automatically for each
-service.
+All Python APIs build from `docker/python.Dockerfile`. The `SERVICE` environment
+variable selects which module to run and `ops/entrypoint.sh` validates imports
+before starting Uvicorn. Health checks hit `/health` by default. Docker Compose
+passes this variable automatically for each service.
 
 To launch the web interface during development:
 ```bash
@@ -97,7 +97,7 @@ the **Variables** tab for the `martech` service.
 
 ## Build-stability contract 🔒
 
-1. Zero network calls in `Dockerfile`.
+1. Zero network calls in `docker/python.Dockerfile`.
 2. `uvicorn services.gateway.app:app` **must start < 2 s** locally and on Railway.
 3. CI blocks merges if lint/type/test fail.
 
@@ -112,8 +112,8 @@ The `docker-compose.yml` file wires them together with sensible defaults for loc
 3. Watch the logs for all services to report `Uvicorn running` within two seconds.
 4. Navigate to `http://localhost:8080/docs` for API docs.
 
-### Reliability principles
-- All Dockerfiles copy only local files and never reach out to the internet during build.
+-### Reliability principles
+- The single Dockerfile (`docker/python.Dockerfile`) copies only local files and never reaches out to the internet during build.
 - Health checks for Railway and Compose are identical so behaviour matches across environments.
 - CI must pass flake8, mypy, and pytest before Docker images are built or published.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   gateway:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: docker/python.Dockerfile
       args:
         SERVICE: gateway
     environment:
@@ -18,7 +18,7 @@ services:
   martech:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: docker/python.Dockerfile
       args:
         SERVICE: martech
     environment:
@@ -35,7 +35,7 @@ services:
   property:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: docker/python.Dockerfile
       args:
         SERVICE: property
     environment:

--- a/docker/python.Dockerfile
+++ b/docker/python.Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONPATH=/app \
+    PORT=8000
+
+WORKDIR /app
+
+# 1. Install deps deterministically via Poetry OR fallback requirements.txt
+COPY pyproject.toml poetry.lock ./
+RUN pip install --no-cache-dir poetry && \
+    poetry config virtualenvs.create false && \
+    poetry install --no-root --no-interaction
+
+# 2. Copy entire repo
+COPY . /app
+
+# 3. (Optional) Fallback if no poetry - leave in place but not used if poetry works
+# RUN test -f requirements.txt && pip install -r requirements.txt || true
+
+# 4. Import check at build time (fail fast)
+ARG SERVICE=gateway
+RUN python /app/ops/validate_import.py
+
+# Healthcheck should be light: only /health
+HEALTHCHECK --interval=5s --timeout=2s --start-period=10s --retries=12 \
+  CMD curl -fsS http://127.0.0.1:${PORT}/health || exit 1
+
+EXPOSE 8000
+
+CMD ["/app/ops/entrypoint.sh"]

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -e
+
+# Expand defaults safely
+SERVICE="${SERVICE:-gateway}"
+PORT="${PORT:-8000}"
+
+# Validate import *before* running uvicorn
+python /app/ops/validate_import.py
+
+# Start uvicorn with fully-qualified path
+exec uvicorn "services.${SERVICE}.app:app" --host 0.0.0.0 --port "${PORT}"

--- a/ops/smoke-test.sh
+++ b/ops/smoke-test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+echo "=== HEALTH ==="
+curl -sS https://$GATEWAY/health | jq .
+curl -sS https://$MARTECH/health | jq .
+curl -sS https://$PROPERTY/health | jq .
+
+echo "=== READY ==="
+curl -sS https://$GATEWAY/ready | jq .
+
+echo "=== ANALYZE adobe.com ==="
+curl -sS -X POST https://$GATEWAY/analyze \
+  -H "Content-Type: application/json" \
+  -d '{"property":{"domain":"adobe.com"}, "martech":{"url":"https://www.adobe.com"}}' | jq .
+
+# end of file

--- a/ops/validate_import.py
+++ b/ops/validate_import.py
@@ -1,0 +1,7 @@
+import importlib
+import os
+
+svc = os.environ.get("SERVICE", "gateway").strip()
+module = f"services.{svc}.app"
+importlib.import_module(module)
+print(f"✅ Successfully imported {module}")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 addopts = -q
-env =
-    PYTHONPATH = {toxinidir}/services:{toxinidir}
+python_paths = services

--- a/railway.toml
+++ b/railway.toml
@@ -4,7 +4,7 @@ schema = "https://railway.com/railway.schema.json"
 # from the root of your repository.
 [build]
 builder = "DOCKERFILE"
-dockerfilePath = "Dockerfile"
+dockerfilePath = "docker/python.Dockerfile"
 
 [deploy]
 healthcheckPath     = "/health"
@@ -16,20 +16,17 @@ healthcheckInterval = 2000
 [[services]]
 name         = "gateway"
 instances    = 1
-# This command tells Railway exactly how to run the gateway service.
-startCommand = "uvicorn services.gateway.app:app --host 0.0.0.0 --port ${PORT:-8000}"
+env = { SERVICE = "gateway" }
 
 [[services]]
 name         = "martech"
 instances    = 1
-# This command tells Railway exactly how to run the martech service.
-startCommand = "uvicorn services.martech.app:app --host 0.0.0.0 --port ${PORT:-8000}"
+env = { SERVICE = "martech" }
 
 [[services]]
 name         = "property"
 instances    = 1
-# This command tells Railway exactly how to run the property service.
-startCommand = "uvicorn services.property.app:app --host 0.0.0.0 --port ${PORT:-8000}"
+env = { SERVICE = "property" }
 
 # The interface service is configured correctly for a Node.js app
 # and remains unchanged.


### PR DESCRIPTION
## Summary
- add shared entrypoint and import validator under `ops/`
- create single docker image recipe in `docker/python.Dockerfile`
- adjust compose and Railway configs to use the new Dockerfile
- document new service startup flow
- simplify pytest path setup

## Testing
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6882f73abd488329b05f271f43191b8b