### PR TITLE
Ensure martech import validation

### DIFF
--- a/ops/validate_import.py
+++ b/ops/validate_import.py
@@ -1,7 +1,11 @@
 import importlib
 import os
 
+allowed = {"gateway", "martech", "property"}
 svc = os.environ.get("SERVICE", "gateway").strip()
+if svc not in allowed:
+    raise SystemExit(f"Unknown service: {svc}")
+
 module = f"services.{svc}.app"
 importlib.import_module(module)
 print(f"✅ Successfully imported {module}")


### PR DESCRIPTION
## Summary
- restrict `ops/validate_import.py` to known services
- allows `martech` imports for build and runtime checks

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882fe416c2c8329ba68954d669b1ba0