### PR TITLE
Add dynamic root ASGI entrypoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+import os
+import importlib
+
+_ALLOWED = {"gateway", "martech", "property"}
+svc = os.getenv("SERVICE", "gateway").strip()
+if svc not in _ALLOWED:
+    raise RuntimeError(f"Unknown service: {svc}")
+module = importlib.import_module(f"services.{svc}.app")
+app = module.app
+

--- a/tests/test_root_app.py
+++ b/tests/test_root_app.py
@@ -1,0 +1,30 @@
+import os
+import importlib
+from fastapi.testclient import TestClient
+
+
+def _load_app(service: str):
+    os.environ["SERVICE"] = service
+    mod = importlib.import_module("app")
+    return importlib.reload(mod).app
+
+
+def test_root_app_gateway():
+    app = _load_app("gateway")
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 200
+
+
+def test_root_app_martech():
+    app = _load_app("martech")
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 200
+
+
+def test_root_app_property():
+    app = _load_app("property")
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- add `app.py` as a dynamic entrypoint for Nixpacks
- test that the new root module loads each service correctly

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68830034fc688329ac898a01b2dadd2a