### PR TITLE
Handle redirects in martech fetch

### DIFF
--- a/services/martech/app.py
+++ b/services/martech/app.py
@@ -64,7 +64,7 @@ def _load_fingerprints(path: Path) -> Dict[str, List[Dict[str, str]]]:
 
 
 async def _fetch(client: httpx.AsyncClient, url: str) -> str:
-    r = await client.get(url)
+    r = await client.get(url, follow_redirects=True)
     r.raise_for_status()
     return r.text
 


### PR DESCRIPTION
## Summary
- allow `_fetch` to follow redirects when grabbing pages
- add test for 301 redirect handling
- update stubs in martech tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68839d5f95408329abee93dd715cf359