### PR TITLE
Add vendor detection scoring

### DIFF
--- a/fingerprints.yaml
+++ b/fingerprints.yaml
@@ -1,10 +1,54 @@
 core:
-  - name: Google Tag Manager
-    pattern: "googletagmanager.com"
   - name: Google Analytics
-    pattern: "google-analytics.com"
+    hosts:
+      - "google-analytics\\.com"
+    scripts:
+      - "ga\\("
+    cookies:
+      - "_ga"
+      - "_gid"
+  - name: Adobe Analytics
+    hosts:
+      - "adobedtm\\.com"
+      - "omtrdc\\.net"
+    scripts:
+      - "s_code"
+    cookies:
+      - "s_pers"
+      - "s_sess"
+  - name: Segment
+    hosts:
+      - "segment\\.com"
+      - "cdn\\.segment\\.com"
+    scripts:
+      - "analytics\\.load"
+    cookies:
+      - "ajs_anonymous_id"
+      - "ajs_user_id"
+  - name: Mixpanel
+    hosts:
+      - "mxpnl\\.com"
+    scripts:
+      - "mixpanel\\.init"
+    cookies:
+      - "mp_"
+  - name: Amplitude
+    hosts:
+      - "amplitude\\.com"
+      - "api\\.amplitude\\.com"
+    scripts:
+      - "amplitude\\.getInstance"
+    cookies:
+      - "amp_"
 adjacent:
   - name: Hotjar
-    pattern: "static.hotjar.com"
+    hosts:
+      - "hotjar\\.com"
+      - "static\\.hotjar\\.com"
+    scripts:
+      - "_hjSettings"
+    cookies:
+      - "_hjSession"
+      - "_hjIncludedInSessionSample"
 broader: []
 competitors: []

--- a/services/shared/utils.py
+++ b/services/shared/utils.py
@@ -21,3 +21,60 @@ def normalize_url(url: str) -> str:
     path = parsed.path.rstrip("/")
 
     return urlunparse((scheme, netloc, path, "", "", ""))
+
+
+def detect_vendors(html: str, cookies: dict[str, str]) -> dict[str, dict]:
+    """Return detected analytics vendors with confidence scores and evidence."""
+    import re
+    import yaml
+    from pathlib import Path
+    from bs4 import BeautifulSoup
+
+    fp_path = Path(__file__).resolve().parents[2] / "fingerprints.yaml"
+    with open(fp_path) as f:
+        fingerprints = yaml.safe_load(f)
+
+    soup = BeautifulSoup(html, "html.parser")
+    srcs = [tag.get("src", "") for tag in soup.find_all("script")]
+    inline = [tag.string or "" for tag in soup.find_all("script") if not tag.get("src")]
+
+    results: dict[str, dict] = {}
+    for bucket, vendors in fingerprints.items():
+        bucket_hits: dict[str, dict] = {}
+        for vendor in vendors:
+            score = 0
+            max_score = 0
+            evidence = {"hosts": [], "scripts": [], "cookies": []}
+
+            hosts = [re.compile(h, re.I) for h in vendor.get("hosts", [])]
+            max_score += len(hosts) * 2
+            for rx in hosts:
+                if any(rx.search(src) for src in srcs):
+                    evidence["hosts"].append(rx.pattern)
+                    score += 2
+
+            scripts = [re.compile(s, re.I) for s in vendor.get("scripts", [])]
+            max_score += len(scripts)
+            for rx in scripts:
+                if any(rx.search(text) for text in inline):
+                    evidence["scripts"].append(rx.pattern)
+                    score += 1
+
+            cookie_names = vendor.get("cookies", [])
+            max_score += len(cookie_names) * 2
+            for name in cookie_names:
+                if name in cookies:
+                    evidence["cookies"].append(name)
+                    score += 2
+
+            if score:
+                confidence = round(score / max(max_score, 1), 2)
+                bucket_hits[vendor["name"]] = {
+                    "confidence": confidence,
+                    "evidence": evidence,
+                }
+
+        if bucket_hits:
+            results[bucket] = bucket_hits
+
+    return results


### PR DESCRIPTION
## Summary
- update analytics fingerprints with host, inline, and cookie data
- add `detect_vendors` utility
- enhance martech service to return cookies, inline scripts, and vendor scores
- expose `/fingerprints` endpoint for debugging
- adjust tests for new detection logic

## Testing
- `tox -e py`

------
https://chatgpt.com/codex/tasks/task_e_6883a48f51d48329a2249cf1e442dbee