### PR TITLE
Add detection tests for martech

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_martech.py
+++ b/tests/test_martech.py
@@ -69,7 +69,7 @@ def test_ready_and_analyze():
         os.environ['HTTPS_PROXY'] = ''
 
         resp = client.post(
-            '/analyze', json={'url': f'http://localhost:{port}/'}
+            '/analyze', json={'url': f'http://localhost:{port}/', 'debug': True}
         )
         data = resp.json()
         assert resp.status_code == 200
@@ -78,6 +78,7 @@ def test_ready_and_analyze():
             assert 'Google Analytics' in core
         else:
             assert 'Google Analytics' in core
+        assert 'debug' in data and 'scripts' in data['debug']
     finally:
         server.shutdown()
 

--- a/tests/test_martech_detection.py
+++ b/tests/test_martech_detection.py
@@ -1,0 +1,60 @@
+import http.cookies
+
+import pytest
+
+from services.shared.utils import detect_vendors
+
+
+@pytest.fixture
+def segment_full():
+    html = (
+        "<script src='https://cdn.segment.com/analytics.js'></script>"
+        "<script>analytics.load('XYZ');</script>"
+    )
+    cookies = {}
+    for header in [
+        "ajs_anonymous_id=abc; Path=/",
+        "ajs_user_id=123; Path=/",
+    ]:
+        c = http.cookies.SimpleCookie()
+        c.load(header)
+        cookies.update({k: v.value for k, v in c.items()})
+    return html, cookies
+
+
+@pytest.fixture
+def segment_partial():
+    html = "<script>analytics.load('XYZ');</script>"
+    c = http.cookies.SimpleCookie()
+    c.load("ajs_anonymous_id=abc; Path=/")
+    cookies = {k: v.value for k, v in c.items()}
+    return html, cookies
+
+
+@pytest.fixture
+def random_page():
+    html = "<script>analyticsLoader('foo');</script>"
+    return html, {}
+
+
+def test_detect_vendors_true_positive(segment_full):
+    html, cookies = segment_full
+    vendors = detect_vendors(html, cookies)
+    seg = vendors["core"]["Segment"]
+    assert pytest.approx(1.0, abs=0.01) == seg["confidence"]
+    assert r"analytics\.load" in seg["evidence"]["scripts"][0]
+
+
+def test_detect_vendors_partial(segment_partial):
+    html, cookies = segment_partial
+    vendors = detect_vendors(html, cookies)
+    seg = vendors["core"]["Segment"]
+    assert pytest.approx(0.33, abs=0.01) == seg["confidence"]
+    assert len(seg["evidence"]["hosts"]) == 0
+
+
+def test_detect_vendors_false_positive(random_page):
+    html, cookies = random_page
+    vendors = detect_vendors(html, cookies)
+    assert vendors == {}
+


### PR DESCRIPTION
## Summary
- add PYTHONPATH setup in tests
- verify vendor scoring in new `test_martech_detection`
- check analyze debug output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883aa1779f08329b21493c88ced0ca9