### PR TITLE
Add GTM host patterns and detection test

### DIFF
--- a/fingerprints.yaml
+++ b/fingerprints.yaml
@@ -2,6 +2,8 @@ core:
   - name: Google Analytics
     hosts:
       - "google-analytics\\.com"
+      - "googletagmanager\\.com"
+      - "www\\.googletagmanager\\.com"
     scripts:
       - "ga\\("
     cookies:
@@ -28,6 +30,9 @@ core:
   - name: Mixpanel
     hosts:
       - "mxpnl\\.com"
+      - "cdn\\.mxpnl\\.com"
+      - "mixpanel\\.com"
+      - "api\\.mixpanel\\.com"
     scripts:
       - "mixpanel\\.init"
     cookies:
@@ -36,6 +41,8 @@ core:
     hosts:
       - "amplitude\\.com"
       - "api\\.amplitude\\.com"
+      - "cdn\\.amplitude\\.com"
+      - "analytics\\.amplitude\\.com"
     scripts:
       - "amplitude\\.getInstance"
     cookies:

--- a/tests/test_martech_detection.py
+++ b/tests/test_martech_detection.py
@@ -37,6 +37,14 @@ def random_page():
     return html, {}
 
 
+@pytest.fixture
+def ga_gtm_url():
+    html = (
+        "<script src='https://www.googletagmanager.com/gtag/js?id=G-XYZ'></script>"
+    )
+    return html, {}
+
+
 def test_detect_vendors_true_positive(segment_full):
     html, cookies = segment_full
     vendors = detect_vendors(html, cookies, [])
@@ -57,3 +65,11 @@ def test_detect_vendors_false_positive(random_page):
     html, cookies = random_page
     vendors = detect_vendors(html, cookies, [])
     assert vendors == {}
+
+
+def test_detect_ga_via_gtm(ga_gtm_url):
+    html, cookies = ga_gtm_url
+    vendors = detect_vendors(html, cookies, [])
+    ga = vendors["core"]["Google Analytics"]
+    assert pytest.approx(0.36, abs=0.01) == ga["confidence"]
+    assert len(ga["evidence"]["hosts"]) == 2


### PR DESCRIPTION
## Summary
- expand analytics host patterns to cover GA via GTM/gtag
- list CDN domains for Mixpanel and Amplitude
- test Google Analytics detection through GTM URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c2eced1c8329884c83405a0c941a