### PR TITLE
Add headless scan option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The gateway orchestrates the other APIs. Key endpoints:
 * `GET /health` – liveness probe.
 * `GET /ready` – checks that downstream services are healthy.
 * `GET /metrics` – optional stats about service calls.
-* `POST /analyze` – body `{"url": "https://example.com"}` returns:
+* `POST /analyze` – body `{"url": "https://example.com", "headless": false}` returns:
   `{"property": {...}, "martech": {...}}`.
 
 `MARTECH_URL` and `PROPERTY_URL` configure the upstream URLs used by the gateway.
@@ -76,9 +76,10 @@ The martech service exposes four endpoints:
 * `GET /health` – liveness probe.
 * `GET /ready` – returns `{"ready": true}` once the fingerprint list is loaded.
 * `GET /diagnose` – checks outbound connectivity.
-* `POST /analyze` – body `{"url": "https://example.com", "debug": false}` returns
+* `POST /analyze` – body `{"url": "https://example.com", "debug": false, "headless": false}` returns
   detected marketing vendors grouped into four buckets. When `debug=true` the
-  response includes detection evidence for each vendor.
+  response includes detection evidence for each vendor. Set `headless=true` to
+  allow a deeper crawl using a headless browser.
 * `GET /fingerprints` – returns the loaded fingerprint definitions. Useful for
   verifying the vendor list in `fingerprints.yaml`.
 

--- a/interface/src/App.test.tsx
+++ b/interface/src/App.test.tsx
@@ -26,7 +26,7 @@ test('shows loading spinner and displays result', async () => {
   server.use(
     http.post('/analyze', async ({ request }) => {
       const body = await request.json()
-      expect(body).toEqual({ url: 'https://example.com' })
+      expect(body).toEqual({ url: 'https://example.com', headless: false })
       await new Promise((r) => setTimeout(r, 1000))
       return Response.json(full)
     })
@@ -46,7 +46,7 @@ test('shows error banner when request fails', async () => {
   server.use(
     http.post('/analyze', async ({ request }) => {
       const body = await request.json()
-      expect(body).toEqual({ url: 'https://example.com' })
+      expect(body).toEqual({ url: 'https://example.com', headless: false })
       return new Response(null, { status: 500 })
     })
   )
@@ -75,7 +75,7 @@ test('shows degraded banner when martech is null', async () => {
   server.use(
     http.post('/analyze', async ({ request }) => {
       const body = await request.json()
-      expect(body).toEqual({ url: 'https://partial.com' })
+      expect(body).toEqual({ url: 'https://partial.com', headless: false })
       return Response.json(partial)
     })
   )

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -23,6 +23,7 @@ export default function App() {
   const [health, setHealth] = useState<'green' | 'yellow' | 'red'>('red')
   const [menuOpen, setMenuOpen] = useState(false)
   const [banner, setBanner] = useState('')
+  const [headless, setHeadless] = useState(false)
   const { showTop } = useScrollPosition()
   useFadeInOnView()
 
@@ -51,7 +52,7 @@ export default function App() {
       const data = await apiFetch<AnalyzeResult>('/analyze', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: clean }),
+        body: JSON.stringify({ url: clean, headless }),
       })
       setResult(data)
     } catch (err) {
@@ -136,6 +137,8 @@ export default function App() {
                 url={url}
                 setUrl={setUrl}
                 onAnalyze={onAnalyze}
+                headless={headless}
+                setHeadless={setHeadless}
                 loading={loading}
                 error={error}
                 result={result}

--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -9,6 +9,8 @@ test('shows spinner when loading', () => {
       url="foo"
       setUrl={() => {}}
       onAnalyze={() => {}}
+      headless={false}
+      setHeadless={() => {}}
       loading={true}
       error=""
       result={null}
@@ -24,6 +26,8 @@ test('displays error message', () => {
       url="foo"
       setUrl={() => {}}
       onAnalyze={() => {}}
+      headless={false}
+      setHeadless={() => {}}
       loading={false}
       error="oops"
       result={null}
@@ -51,6 +55,8 @@ test('renders result lists', () => {
       url="foo"
       setUrl={() => {}}
       onAnalyze={() => {}}
+      headless={false}
+      setHeadless={() => {}}
       loading={false}
       error=""
       result={result}
@@ -67,6 +73,8 @@ test('shows degraded banner', () => {
       url="foo"
       setUrl={() => {}}
       onAnalyze={() => {}}
+      headless={false}
+      setHeadless={() => {}}
       loading={false}
       error=""
       result={{ ...result, degraded: true }}

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -16,12 +16,24 @@ export type AnalyzerProps = {
   url: string
   setUrl: (v: string) => void
   onAnalyze: () => void
+  headless: boolean
+  setHeadless: (v: boolean) => void
   loading: boolean
   error: string
   result: AnalyzeResult | null
 }
 
-export default function AnalyzerCard({ id, url, setUrl, onAnalyze, loading, error, result }: AnalyzerProps) {
+export default function AnalyzerCard({
+  id,
+  url,
+  setUrl,
+  onAnalyze,
+  headless,
+  setHeadless,
+  loading,
+  error,
+  result,
+}: AnalyzerProps) {
   if (result) {
     const { property, martech, degraded } = result
     return (
@@ -72,6 +84,15 @@ export default function AnalyzerCard({ id, url, setUrl, onAnalyze, loading, erro
           )}
         </button>
       </div>
+      <label className="flex items-center mt-4 text-sm">
+        <input
+          type="checkbox"
+          checked={headless}
+          onChange={(e) => setHeadless(e.target.checked)}
+          className="mr-2"
+        />
+        Enable deep scan
+      </label>
     </div>
   )
 }

--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -62,6 +62,7 @@ def record_failure(service: str, status_code: int | None = None) -> None:
 class AnalyzeRequest(BaseModel):
     url: str
     debug: bool | None = False
+    headless: bool | None = False
 
     @root_validator(pre=True)
     def _allow_domain(cls, values: dict) -> dict:  # noqa: D401
@@ -163,7 +164,7 @@ async def analyze(req: AnalyzeRequest) -> JSONResponse:
 
     martech_task = _post_with_retry(
         f"{MARTECH_URL}/analyze",
-        {"url": clean_url, "debug": req.debug},
+        {"url": clean_url, "debug": req.debug, "headless": req.headless},
         "martech",
     )
     property_task = _post_with_retry(

--- a/services/martech/app.py
+++ b/services/martech/app.py
@@ -43,6 +43,7 @@ cache: Dict[str, Dict[str, Any]] = {}
 class AnalyzeRequest(BaseModel):
     url: str
     debug: bool | None = False
+    headless: bool | None = False
 
 
 class DiagnoseResponse(BaseModel):
@@ -223,7 +224,9 @@ async def analyze(req: AnalyzeRequest) -> JSONResponse:
         result = entry["data"]
     else:
         try:
-            result = await analyze_url(url, debug=bool(req.debug))
+            result = await analyze_url(
+                url, debug=bool(req.debug), headless=bool(req.headless)
+            )
         except (httpx.RequestError, asyncio.TimeoutError):
             logging.exception("failed analyzing URL")
             return JSONResponse(

--- a/tests/test_martech_detection.py
+++ b/tests/test_martech_detection.py
@@ -40,7 +40,8 @@ def random_page():
 @pytest.fixture
 def ga_gtm_url():
     html = (
-        "<script src='https://www.googletagmanager.com/gtag/js?id=G-XYZ'></script>"
+        "<script src='https://www.googletagmanager.com/gtag/js?id=G-XYZ'>"
+        "</script>"
     )
     return html, {}
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     fastapi
     pyyaml
     beautifulsoup4
+    pytest-asyncio
 commands = pytest
 
 [testenv:lint]


### PR DESCRIPTION
## Summary
- expose optional `headless` flag in gateway and martech AnalyzeRequest models
- forward `headless` from gateway to martech analyzer
- allow UI users to enable deep scan via checkbox
- document the new parameter
- fix tests and lint

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6883d7c3964083298d13f621cf58baf3