### PR TITLE
Add debug option for fingerprints endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ The martech service exposes four endpoints:
   response includes detection evidence for each vendor. Set `headless=true` to
   allow a deeper crawl using a headless browser. Pass `force=true` to bypass the
   in-memory cache and refresh the analysis immediately.
-* `GET /fingerprints` – returns the loaded fingerprint definitions. Useful for
-  verifying the vendor list in `fingerprints.yaml`.
+* `GET /fingerprints` – returns the loaded fingerprint definitions. Append
+  `?debug=true` to run detection on a sample page and show which evidence types
+  triggered for each vendor.
 
 Fingerprint definitions live in `fingerprints.yaml`. Edit this file and restart
 the service to update the vendor list.

--- a/tests/test_martech.py
+++ b/tests/test_martech.py
@@ -272,6 +272,16 @@ def test_fingerprints_endpoint():
     )
 
 
+def test_fingerprints_debug():
+    client.get("/ready")
+    r = client.get("/fingerprints?debug=true")
+    assert r.status_code == 200
+    data = r.json()
+    assert "core" in data
+    assert set(data["core"]["Google Analytics"]) == {"hosts", "scripts"}
+    assert set(data["core"]["Segment"]) == {"hosts", "scripts"}
+
+
 @pytest.mark.asyncio
 async def test_extract_scripts_parses_gtm(monkeypatch):
     html = "<script src='https://www.googletagmanager.com/gtm.js'></script>"


### PR DESCRIPTION
## Summary
- add `debug` query parameter to `/fingerprints`
- display vendor evidence types when debug enabled
- document new usage
- test new behaviour

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6883e16ca114832983597d24b71f79e2