### PR TITLE
Fetch external script contents for vendor detection

### DIFF
--- a/services/shared/utils.py
+++ b/services/shared/utils.py
@@ -31,12 +31,15 @@ def detect_vendors(
     cookies: dict[str, str],
     urls: Sequence[str] | None = None,
     fingerprints: dict[str, list[dict]] | None = None,
+    script_bodies: Sequence[str] | None = None,
 ) -> dict[str, dict]:
     """Return detected analytics vendors with confidence scores and evidence.
 
     ``urls`` is an optional collection of additional resource URLs (script
     sources, image URLs, resource hints, etc.) that should be considered when
-    matching vendor host fingerprints.
+    matching vendor host fingerprints. ``script_bodies`` may contain additional
+    JavaScript text (e.g. from externally hosted scripts) which will be matched
+    against script patterns.
     """
     import re
     import yaml  # type: ignore
@@ -57,6 +60,8 @@ def detect_vendors(
         for tag in soup.find_all("script")
         if not tag.get("src")
     ]
+    if script_bodies:
+        inline.extend(script_bodies)
 
     results: dict[str, dict] = {}
     for bucket, vendors in fingerprints.items():

--- a/tests/test_martech_detection.py
+++ b/tests/test_martech_detection.py
@@ -108,3 +108,17 @@ def test_detect_adobe_via_satellite(adobe_satellite):
     adobe = vendors["core"]["Adobe Analytics"]
     assert pytest.approx(0.10, abs=0.01) == adobe["confidence"]
     assert r"window\._satellite" in adobe["evidence"]["scripts"][0]
+
+
+def test_detect_with_external_scripts():
+    html = "<script src='/ga.js'></script><script src='/seg.js'></script>"
+    vendors = detect_vendors(
+        html,
+        {},
+        [],
+        FINGERPRINTS,
+        script_bodies=["ga('create','UA-1','auto');", "analytics.load('XYZ');"],
+    )
+    core = vendors["core"]
+    assert "Google Analytics" in core
+    assert "Segment" in core


### PR DESCRIPTION
## Summary
- fetch external script bodies in `_extract_scripts`
- join relative script URLs against the page URL
- allow `detect_vendors` to consume additional script bodies
- update martech analysis to pass fetched scripts
- test detection using local GA and Segment scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e8fd1b308329b692d54df15aef13