### PR TITLE
Fix CMS header matcher names

### DIFF
--- a/cms_fingerprints.yaml
+++ b/cms_fingerprints.yaml
@@ -12,7 +12,7 @@ vendors:
         pattern: wp-content/
       - type: html
         pattern: "wp-"
-      - type: header
+      - type: response_header
         name: x-generator
         pattern: WordPress
       - type: cookie
@@ -22,7 +22,7 @@ vendors:
     matchers:
       - type: html
         pattern: Drupal.settings
-      - type: header
+      - type: response_header
         name: x-generator
         pattern: Drupal
   - name: Joomla


### PR DESCRIPTION
## Summary
- align matcher name with services' `_PATTERN_TYPES`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68854d7868f483298f5e8d78557cb529