### PR TITLE
Update README on martech network errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ The martech service exposes four endpoints:
   evidence types triggered for each vendor. Results are cached so repeated calls
   are instant.
 
+If fetching the page fails, the service falls back to analyzing just the URL.
+Results are still returned but include a `"network_error"` indicator set to
+`true`.
+
 Example:
 
 ```bash


### PR DESCRIPTION
## Summary
- document network_error fallback in martech README section

## Testing
- `make lint` *(fails: flake8/mypy errors)*
- `make test` *(fails: 1 failing test and blocked network requests)*

------
https://chatgpt.com/codex/tasks/task_e_688551935ad88329bc7a7a40f78e6df7