### PR TITLE
Switch to new httpx proxy param

### DIFF
--- a/services/martech/app.py
+++ b/services/martech/app.py
@@ -191,10 +191,7 @@ async def analyze_url(
     )
     client_opts: Dict[str, Any] = {"timeout": 10}
     if proxy:
-        client_opts["proxies"] = {
-            "http://": proxy,
-            "https://": proxy,
-        }
+        client_opts["proxy"] = proxy
     network_error = False
     async with httpx.AsyncClient(**client_opts) as client:
         try:
@@ -379,10 +376,7 @@ async def diagnose() -> DiagnoseResponse:
     )
     client_opts: Dict[str, Any] = {"timeout": 5}
     if proxy:
-        client_opts["proxies"] = {
-            "http://": proxy,
-            "https://": proxy,
-        }
+        client_opts["proxy"] = proxy
     try:
         async with httpx.AsyncClient(**client_opts) as client:
             await client.get("https://example.com")

--- a/tests/test_martech.py
+++ b/tests/test_martech.py
@@ -190,17 +190,14 @@ def test_proxy_usage(monkeypatch):
     captured = {}
 
     def hook(kwargs: dict) -> None:
-        captured["proxies"] = kwargs.get("proxies")
+        captured["proxy"] = kwargs.get("proxy")
 
     _set_stub_client(monkeypatch, hook)
     monkeypatch.setenv("OUTBOUND_HTTP_PROXY", "http://proxy.local")
 
     r = client.get("/diagnose")
     assert r.status_code == 200
-    assert captured["proxies"] == {
-        "http://": "http://proxy.local",
-        "https://": "http://proxy.local",
-    }
+    assert captured["proxy"] == "http://proxy.local"
 
 
 def test_analyze_uses_proxy(monkeypatch):
@@ -209,7 +206,7 @@ def test_analyze_uses_proxy(monkeypatch):
     captured = {}
 
     def hook(kwargs: dict) -> None:
-        captured["proxies"] = kwargs.get("proxies")
+        captured["proxy"] = kwargs.get("proxy")
 
     _set_stub_client(monkeypatch, hook)
     monkeypatch.setenv("OUTBOUND_HTTP_PROXY", "http://proxy.local")
@@ -218,10 +215,7 @@ def test_analyze_uses_proxy(monkeypatch):
         "/analyze", json={"url": "http://example.com", "force": True}
     )
     assert r.status_code == 200
-    assert captured["proxies"] == {
-        "http://": "http://proxy.local",
-        "https://": "http://proxy.local",
-    }
+    assert captured["proxy"] == "http://proxy.local"
 
 
 def test_diagnose_mocked_asyncclient_success(monkeypatch):


### PR DESCRIPTION
## Summary
- use `client_opts["proxy"]` when creating httpx clients
- adjust martech tests to capture the new proxy argument

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6885557cdf6883298b54fc8ae49727fd