### PR TITLE
Fix fetch error handling and test spacing

### DIFF
--- a/services/martech/app.py
+++ b/services/martech/app.py
@@ -193,10 +193,16 @@ async def analyze_url(
     if proxy:
         client_opts["proxy"] = proxy
     network_error = False
+    script_urls: set[str]
+    inline: list[str]
+    external: list[str]
     async with httpx.AsyncClient(**client_opts) as client:
         try:
             html, resp_headers, resp_cookies = await _fetch(client, url)
-        except (httpx.RequestError, asyncio.TimeoutError) as exc:  # noqa: BLE001
+        except (
+            httpx.RequestError,
+            asyncio.TimeoutError,
+        ):  # noqa: BLE001
             logging.exception("failed fetching %s", url)
             network_error = True
             html = ""

--- a/tests/test_cms_detection.py
+++ b/tests/test_cms_detection.py
@@ -58,6 +58,7 @@ def test_no_match(random_page):
     assert result == {}
 
 @pytest.mark.asyncio
+
 async def test_analyze_url_handles_fetch_error(monkeypatch):
     async def boom_fetch(_client, url):
         req = httpx.Request("GET", url)


### PR DESCRIPTION
## Summary
- properly declare typed variables for script parsing
- handle fetch exceptions without assigning the exception object
- separate the async test definition in `tests/test_cms_detection.py`

## Testing
- `tox -e py`

------
https://chatgpt.com/codex/tasks/task_e_68855770fef083298705f5714cd7ef1a