### PR TITLE
Update CMS fingerprints and adjust tests

### DIFF
--- a/cms_fingerprints.yaml
+++ b/cms_fingerprints.yaml
@@ -1,51 +1,406 @@
 schema_version: 1
 scoring:
-  url: 2
-  html: 1
-  headers: 2
-  cookies: 2
+  method: additive          # sum of matched weights
+  default_threshold: 0.80   # vendor-level default unless overridden
+
 vendors:
-  - name: WordPress
-    website: https://wordpress.org
+  - id: aem
+    name: Adobe Experience Manager (AEM)
+    category: enterprise_cms
+    threshold: 0.85
     matchers:
+      - type: path
+        pattern: '/etc\\.clientlibs/.+'
+        weight: 0.45
+      - type: path
+        pattern: '/content/.+\\.model\\.json$'
+        weight: 0.55
+      - type: html
+        pattern: 'data-cq-data-path'
+        weight: 0.35
+      - type: html
+        pattern: '/libs/granite/|granite\\.ui'
+        weight: 0.30
+      - type: response_header
+        name: "Server"
+        pattern: 'Apache Sling|Adobe Experience Manager'
+        weight: 0.25
+    notes: |
+      Use combination of Sling Model Exporter (*.model.json) and clientlibs proxy path.
+
+  - id: aem_eds
+    name: Adobe Edge Delivery Services (AEM EDS)
+    category: delivery_layer
+    threshold: 0.85
+    matchers:
+      - type: hostname
+        pattern: '([^.]+\\.)*aem\\.live$'
+        weight: 0.75
+      - type: hostname
+        pattern: '([^.]+\\.)*aem\\.page$'
+        weight: 0.70
       - type: url
-        pattern: wp-content/
-      - type: html
-        pattern: "wp-"
-      - type: response_header
-        name: x-generator
-        pattern: WordPress
+        pattern: 'hlx\\.(live|page)'
+        weight: 0.40
+      - type: script_url
+        pattern: '/tools/sidekick(\\.min)?\\.js'
+        weight: 0.40
+      - type: response_body
+        pattern: '\\b(blocks|fstab\\.yaml|aem\\.live)\\b'
+        weight: 0.25
+    notes: |
+      Helix 4 used fstab.yaml; Helix 5 is repo-less and managed via Configuration Service. Prefer domain match + Sidekick.
+
+  - id: sitecore
+    name: Sitecore (XP / XM Cloud)
+    category: enterprise_cms
+    threshold: 0.80
+    matchers:
       - type: cookie
-        name: wordpress_test_cookie
-  - name: Drupal
-    website: https://drupal.org
+        name: "SC_ANALYTICS_GLOBAL_COOKIE"
+        weight: 0.70
+      - type: cookie
+        name: "SC_ANALYTICS_SESSION_COOKIE"
+        weight: 0.40
+      - type: path
+        pattern: '/sitecore/service/|/sitecore/shell/|/sitecore/api/'
+        weight: 0.40
+
+  - id: drupal
+    name: Drupal (incl. Acquia Drupal)
+    category: oss_cms
+    threshold: 0.80
     matchers:
-      - type: html
-        pattern: Drupal.settings
       - type: response_header
-        name: x-generator
-        pattern: Drupal
-  - name: Joomla
-    website: https://www.joomla.org
-    matchers:
+        name: "X-Generator"
+        pattern: 'Drupal'
+        weight: 0.50
       - type: html
-        pattern: Joomla!
-  - name: Squarespace
-    website: https://www.squarespace.com
+        pattern: '<meta[^>]*name=[\"'']?Generator[\"'']?[^>]*Drupal'
+        weight: 0.45
+      - type: path
+        pattern: '/sites/default/files/'
+        weight: 0.40
+      - type: response_header
+        name: "X-Drupal-Cache|X-Drupal-Dynamic-Cache"
+        pattern: '.+'
+        weight: 0.35
+      - type: response_header
+        name: "X-AH-Environment"
+        pattern: '.+'
+        weight: 0.35
+    notes: |
+      Acquia often adds X-AH-Environment and Varnish via headers; many sites strip X-Generator—fallback to paths.
+
+  - id: wordpress
+    name: WordPress
+    category: oss_cms
+    threshold: 0.75
     matchers:
+      - type: path
+        pattern: '/wp-(content|includes)/'
+        weight: 0.55
       - type: html
-        pattern: squarespace.com
-  - name: Wix
-    website: https://www.wix.com
-    matchers:
-      - type: html
-        pattern: wix.com
-  - name: Adobe Experience Manager
-    website: https://www.adobe.com/marketing/experience-manager.html
-    matchers:
-      - type: html
-        pattern: aem-Grid
+        pattern: '<meta[^>]*name=[\"'']?generator[\"'']?[^>]*WordPress'
+        weight: 0.45
       - type: script_url
-        pattern: /etc.clientlibs/
+        pattern: 'wp-emoji-release\\.min\\.js'
+        weight: 0.35
+
+  - id: shopify
+    name: Shopify
+    category: commerce_cms
+    threshold: 0.80
+    matchers:
+      - type: response_header
+        name: "X-Sorting-Hat-PodId|X-Sorting-Hat-ShopId|X-ShopId|X-Shopify-Stage|X-ShardId"
+        pattern: '.+'
+        weight: 0.70
+      - type: asset_host
+        pattern: 'cdn\\.shopify\\.com'
+        weight: 0.50
+
+  - id: magento
+    name: Adobe Commerce / Magento
+    category: commerce_cms
+    threshold: 0.80
+    matchers:
+      - type: cookie
+        name: "form_key"
+        weight: 0.45
+      - type: cookie
+        name: "mage-cache-sessid"
+        weight: 0.35
+      - type: cookie
+        name: "mage-cache-storage"
+        weight: 0.35
+      - type: cookie
+        name: "mage-cache-storage-section-invalidation"
+        weight: 0.35
+      - type: cookie
+        name: "X-Magento-Vary"
+        weight: 0.35
+      - type: path
+        pattern: '/static/version\\d+/.+|/media/.+'
+        weight: 0.30
+
+  - id: contentful
+    name: Contentful
+    category: headless_saas
+    threshold: 0.80
+    matchers:
+      - type: api_host
+        pattern: 'cdn\\.contentful\\.com|preview\\.contentful\\.com|graphql\\.contentful\\.com'
+        weight: 0.80
+      - type: response_header
+        name: "x-contentful-request-id|x-contentful-space-id"
+        pattern: '.+'
+        weight: 0.50
+
+  - id: contentstack
+    name: Contentstack
+    category: headless_saas
+    threshold: 0.80
+    matchers:
+      - type: api_host
+        pattern: 'cdn\\.contentstack\\.io|api\\.contentstack\\.io|images\\.contentstack\\.io'
+        weight: 0.80
+
+  - id: sanity
+    name: Sanity
+    category: headless_saas
+    threshold: 0.80
+    matchers:
+      - type: api_host
+        pattern: 'cdn\\.sanity\\.io'
+        weight: 0.70
+      - type: response_body
+        pattern: '\\bprojectId\\s*:\s*[''\"][a-z0-9]+[''\"],\\s*dataset\\s*:'
+        weight: 0.40
+
+  - id: storyblok
+    name: Storyblok
+    category: headless_saas
+    threshold: 0.80
+    matchers:
       - type: script_url
-        pattern: /etc/designs/
+        pattern: 'app\\.storyblok\\.com/f/storyblok-v2-latest\\.js'
+        weight: 0.80
+      - type: response_body
+        pattern: '\\bStoryblokBridge\\b'
+        weight: 0.50
+      - type: api_host
+        pattern: 'api\\.storyblok\\.com|cdn\\.storyblok\\.com'
+        weight: 0.50
+
+  - id: hygraph
+    name: Hygraph (GraphCMS)
+    category: headless_saas
+    threshold: 0.80
+    matchers:
+      - type: api_host
+        pattern: 'api-[a-z0-9-]+\\.hygraph\\.com'
+        weight: 0.80
+
+  - id: prismic
+    name: Prismic
+    category: headless_saas
+    threshold: 0.80
+    matchers:
+      - type: script_url
+        pattern: '//(static\\.)?cdn\\.prismic\\.io/prismic\\.js\\?new=true&repo='
+        weight: 0.70
+      - type: api_host
+        pattern: 'cdn\\.prismic\\.io'
+        weight: 0.60
+
+  - id: strapi
+    name: Strapi
+    category: headless_oss
+    threshold: 0.75
+    matchers:
+      - type: response_header
+        name: "X-Powered-By"
+        pattern: 'Strapi'
+        weight: 0.65
+      - type: path
+        pattern: '/admin($|/)|^/api/[a-z0-9_-]+'
+        weight: 0.45
+
+  - id: kentico_xperience
+    name: Kentico Xperience
+    category: enterprise_cms
+    threshold: 0.80
+    matchers:
+      - type: cookie
+        name: "CMSPreferredCulture"
+        weight: 0.55
+      - type: cookie
+        name: "CMSVirtualContextIdentity"
+        weight: 0.55
+      - type: cookie
+        name: "CMSCurrentTheme"
+        weight: 0.35
+
+  - id: kontent_ai
+    name: Kontent.ai
+    category: headless_saas
+    threshold: 0.80
+    matchers:
+      - type: response_header
+        name: "X-Kontent-ai-Signature|X-KC-Signature"
+        pattern: '.+'
+        weight: 0.60
+      - type: api_host
+        pattern: 'deliver(k|y)\\.kontent\\.ai|kontent\\.ai'
+        weight: 0.60
+
+  - id: umbraco
+    name: Umbraco (incl. Heartcore)
+    category: oss_cms
+    threshold: 0.80
+    matchers:
+      - type: cookie
+        name: "UMB-XSRF-TOKEN"
+        weight: 0.55
+      - type: cookie
+        name: "UMB-XSRF-V"
+        weight: 0.45
+      - type: cookie
+        name: "UMB_SESSION"
+        weight: 0.35
+      - type: response_header
+        name: "X-Umbraco-Version"
+        pattern: '.+'
+        weight: 0.35
+
+  - id: magnolia
+    name: Magnolia
+    category: enterprise_cms
+    threshold: 0.80
+    matchers:
+      - type: path
+        pattern: '/\\.resources/.+~\\d{4}-\\d{2}-\\d{2}.+~cache\\.(css|js)$'
+        weight: 0.70
+      - type: cookie
+        name: "JSESSIONID"
+        weight: 0.30
+
+  - id: liferay
+    name: Liferay DXP
+    category: enterprise_cms
+    threshold: 0.80
+    matchers:
+      - type: response_header
+        name: "Server|X-Powered-By"
+        pattern: 'Liferay-Portal'
+        weight: 0.70
+      - type: cookie
+        name: "LFR_SESSION_STATE_"
+        weight: 0.45
+
+  - id: bloomreach
+    name: Bloomreach Content (Hippo)
+    category: enterprise_cms
+    threshold: 0.80
+    matchers:
+      - type: path
+        pattern: '/binaries/.+'
+        weight: 0.65
+      - type: response_body
+        pattern: 'org\\.hippoecm\\.hst'
+        weight: 0.45
+
+  - id: coremedia
+    name: CoreMedia
+    category: enterprise_cms
+    threshold: 0.80
+    matchers:
+      - type: path
+        pattern: '/graphql($|\\?)'
+        weight: 0.40
+      - type: response_body
+        pattern: '\\bCoreMedia\\b'
+        weight: 0.50
+
+  - id: tridion
+    name: SDL Tridion Sites (RWS)
+    category: enterprise_cms
+    threshold: 0.80
+    matchers:
+      - type: response_body
+        pattern: '\\btcm:\\d+-\\d+(-\\d+)?\\b'
+        weight: 0.60
+      - type: path
+        pattern: '/Navigation\\.json$|/sitemap\\.json$'
+        weight: 0.40
+
+  - id: sitefinity
+    name: Progress Sitefinity
+    category: enterprise_cms
+    threshold: 0.80
+    matchers:
+      - type: cookie
+        name: "sf-tracking-consent"
+        weight: 0.60
+      - type: cookie
+        name: "sf-prs-"
+        weight: 0.50
+
+  - id: optimizely_cms
+    name: Optimizely CMS (Episerver)
+    category: enterprise_cms
+    threshold: 0.80
+    matchers:
+      - type: cookie
+        name: "EPi:NumberOfVisits"
+        weight: 0.60
+      - type: cookie
+        name: "EPiSessionId"
+        weight: 0.45
+
+  - id: craft
+    name: Craft CMS
+    category: oss_cms
+    threshold: 0.80
+    matchers:
+      - type: cookie
+        name: "CraftSessionId"
+        weight: 0.65
+      - type: response_header
+        name: "X-Powered-By"
+        pattern: 'Craft CMS'
+        weight: 0.45
+      - type: path
+        pattern: '/cpresources/\\w+/'
+        weight: 0.45
+
+  - id: ghost
+    name: Ghost
+    category: headless_oss
+    threshold: 0.80
+    matchers:
+      - type: html
+        pattern: '<meta[^>]*name=[\"'']generator[\"''][^>]*Ghost'
+        weight: 0.60
+      - type: path
+        pattern: '^/ghost(/|$)'
+        weight: 0.50
+      - type: api_host
+        pattern: '/ghost/api/(content|admin)/v\\d+/'
+        weight: 0.50
+
+  - id: typo3
+    name: TYPO3
+    category: oss_cms
+    threshold: 0.80
+    matchers:
+      - type: cookie
+        name: "fe_typo_user"
+        weight: 0.55
+      - type: cookie
+        name: "be_typo_user"
+        weight: 0.45
+      - type: response_body
+        pattern: 'JWT|HS256'
+        weight: 0.25

--- a/tests/test_martech.py
+++ b/tests/test_martech.py
@@ -380,7 +380,11 @@ def test_local_scripts_detected(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_analyze_url_detects_cms(monkeypatch):
-    html = "<html>wp-content</html>"
+    html = (
+        "<html><link href='/wp-content/style.css'>"
+        "<meta name='generator' content='WordPress'>"
+        "<script src='wp-emoji-release.min.js'></script></html>"
+    )
     headers = {"X-Generator": "WordPress"}
     cookies = {"wordpress_test_cookie": "1"}
 
@@ -394,10 +398,10 @@ async def test_analyze_url_detects_cms(monkeypatch):
     monkeypatch.setattr("services.martech.app._extract_scripts", fake_extract)
 
     result = await services.martech.app.analyze_url(
-        "http://example.com", debug=True
+        "http://example.com/wp-content/", debug=True
     )
     cms = result["cms"]
-    assert "WordPress" in cms.get("uncategorized", {})
+    assert "WordPress" in cms.get("oss_cms", {})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace `cms_fingerprints.yaml` with new CMS definitions
- ensure response headers use the expected `name:` key
- adapt tests to new matcher weights and categories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855cbd2ba483299342329e490ec3cc