### PR TITLE
Extract CMS list in gateway responses

### DIFF
--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -186,9 +186,11 @@ async def analyze(req: AnalyzeRequest) -> JSONResponse:
     martech_data, martech_degraded = martech_res
     property_data, property_degraded = property_res
 
+    cms_list = martech_data.pop("cms", []) if martech_data else []
     result = {
         "property": property_data,
-        "martech": martech_data,
+        "martech": martech_data or {},
+        "cms": cms_list,
         "degraded": martech_degraded or property_degraded,
     }
     return JSONResponse(result)


### PR DESCRIPTION
## Summary
- expose CMS results separately in gateway analyze route
- update tests for new `cms` key
- add unit test for CMS extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688581667c848329a66012c74c3eeddb