### PR TITLE
Fix context_opts typing for Playwright

### DIFF
--- a/services/martech/app.py
+++ b/services/martech/app.py
@@ -144,7 +144,7 @@ async def _headless_request(url: str, proxy: str | None = None) -> str:
     try:
         async with async_playwright() as pw:
             browser = await pw.firefox.launch(headless=True)
-            context_opts = {"java_script_enabled": False}
+            context_opts: dict[str, Any] = {"java_script_enabled": False}
             if proxy:
                 context_opts["proxy"] = {"server": proxy}
             context = await browser.new_context(**context_opts)


### PR DESCRIPTION
## Summary
- annotate `context_opts` in `services/martech/app.py` with `dict[str, Any]`

## Testing
- `tox -e type`
- `tox -e py`

------
https://chatgpt.com/codex/tasks/task_e_688585cd439c8329adeba683986f67ad