### PR TITLE
Fix flake8 issues in martech tests

### DIFF
--- a/tests/test_martech.py
+++ b/tests/test_martech.py
@@ -246,8 +246,14 @@ async def test_headless_playwright_uses_proxy(monkeypatch):
 
     monkeypatch.setattr("services.martech.app._fetch", fake_fetch)
     monkeypatch.setattr("services.martech.app._extract_scripts", fake_extract)
-    monkeypatch.setattr("services.martech.app.detect_vendors", lambda *a, **k: {})
-    monkeypatch.setattr("services.martech.app.match_fingerprints", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "services.martech.app.detect_vendors",
+        lambda *a, **k: {},
+    )
+    monkeypatch.setattr(
+        "services.martech.app.match_fingerprints",
+        lambda *a, **k: {},
+    )
     monkeypatch.setattr("services.martech.app.cms_fingerprints", {})
 
     captured: dict[str, object] = {}
@@ -289,7 +295,8 @@ async def test_headless_playwright_uses_proxy(monkeypatch):
     def dummy_async_playwright():
         return DummyAP()
 
-    import types, sys
+    import types
+    import sys
 
     dummy_module = types.ModuleType("playwright.async_api")
     dummy_module.async_playwright = dummy_async_playwright


### PR DESCRIPTION
## Summary
- break long lambda monkeypatch calls over multiple lines
- split a combined import into two separate statements

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6885879439988329aaf727255458314a