### PR TITLE
Show CMS placeholder when no matches

### DIFF
--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { test, expect } from 'vitest'
 import AnalyzerCard, { type AnalyzeResult } from './AnalyzerCard'
 
@@ -89,4 +89,26 @@ test('shows degraded banner', () => {
     />,
   )
   expect(screen.getByText(/partial results/i)).toBeInTheDocument()
+})
+
+test('shows CMS placeholder when array empty', () => {
+  render(
+    <AnalyzerCard
+      id="a"
+      url="foo"
+      setUrl={() => {}}
+      onAnalyze={() => {}}
+      headless={false}
+      setHeadless={() => {}}
+      force={false}
+      setForce={() => {}}
+      loading={false}
+      error=""
+      result={{ ...result, cms: [] }}
+    />,
+  )
+  const cmsSection = screen.getByRole('heading', {
+    name: 'Content Management Systems',
+  }).parentElement as HTMLElement
+  expect(within(cmsSection).getByText('Nothing detected')).toBeInTheDocument()
 })

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -52,7 +52,7 @@ export default function AnalyzerCard({
         )}
         {property && <PropertyResults property={property} />}
         {martech && <MartechResults martech={martech} />}
-        {cms && cms.length > 0 && <CmsResults cms={cms} />}
+        {cms != null && <CmsResults cms={cms} />}
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- always render `<CmsResults>` when CMS data exists
- check for empty CMS results in `AnalyzerCard.test.tsx`

## Testing
- `npm test` in `interface`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885afe7c4d88329bf2d8cb56586e76c