### PR TITLE
Add CmsResults unit tests

### DIFF
--- a/interface/src/components/CmsResults.test.tsx
+++ b/interface/src/components/CmsResults.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import { test } from 'vitest'
+import CmsResults from './CmsResults'
+
+test('renders cms names', () => {
+  render(<CmsResults cms={['WordPress', 'Drupal']} />)
+  screen.getByText('WordPress')
+  screen.getByText('Drupal')
+})
+
+test('shows fallback when empty', () => {
+  render(<CmsResults cms={[]} />)
+  screen.getByText('Nothing detected')
+})


### PR DESCRIPTION
## Summary
- add Vitest tests for CmsResults component

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6885b482cda483299490aa54ca03ef40