### PR TITLE
Add manual CMS logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ curl -X POST http://localhost:8080/generate \
   -d '{"url": "https://example.com", "martech": {}, "cms": [], "cms_manual": "Drupal"}'
 ```
 
+Set `CMS_MANUAL_LOG_PATH` to a file path to record submitted `cms_manual`
+values. Reviewing these logs helps refine `cms_fingerprints.yaml` with real
+world platforms not yet covered by automated detection.
+
 ## Deployment
 
 * GitHub Actions installs dependencies from `pyproject.toml` and runs our test

--- a/tests/test_martech.py
+++ b/tests/test_martech.py
@@ -583,3 +583,22 @@ def test_generate_detected_cms():
     assert r.status_code == 200
     data = r.json()
     assert data["cms_used"] == "WordPress"
+
+
+def test_cms_manual_logging(tmp_path, monkeypatch):
+    path = tmp_path / "cms.log"
+    monkeypatch.setattr(services.martech.app, "CMS_MANUAL_LOG_PATH", str(path))
+    services.martech.app._cms_log_file = None
+
+    r = client.post(
+        "/generate",
+        json={
+            "url": "http://example.com",
+            "martech": {},
+            "cms": [],
+            "cms_manual": "Joomla",
+        },
+    )
+    assert r.status_code == 200
+    text = path.read_text().strip()
+    assert text.endswith("Joomla")


### PR DESCRIPTION
## Summary
- allow martech service to optionally log `cms_manual` strings
- document CMS_MANUAL_LOG_PATH
- test manual CMS logging works

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6885b8fbfc20832980e9abea98049f8d