### PR TITLE
Use InsightCard for generated insights

### DIFF
--- a/interface/src/utils/insightParser.ts
+++ b/interface/src/utils/insightParser.ts
@@ -49,8 +49,17 @@ export function parseInsightPayload(payload: unknown): ParsedInsight {
     data = { ...data, ...data.report }
   }
 
-  const summary =
-    (getValue(data, ['summary', 'insight', 'report', 'text']) as string | undefined) || ''
+  const summaryRaw = getValue(data, ['summary', 'insight', 'report', 'text'])
+  let summary = ''
+  if (typeof summaryRaw === 'string') {
+    summary = summaryRaw
+  } else if (summaryRaw && typeof summaryRaw === 'object') {
+    const nested = getValue(summaryRaw, ['summary', 'insight', 'report', 'text'])
+    if (typeof nested === 'string') summary = nested
+    else summary = JSON.stringify(summaryRaw)
+  } else if (summaryRaw != null) {
+    summary = String(summaryRaw)
+  }
 
   let personas: Persona[] = []
   const personaRaw =


### PR DESCRIPTION
## Summary
- parse insight payload when generating new insights
- show `<InsightCard>` instead of raw JSON
- improve insight parser to drill into nested fields

## Testing
- `npm test --silent` in `interface`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888387702788329b4d3bc7f5d36f9cc