### PR TITLE
Add InsightCard test suite

### DIFF
--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -153,8 +153,11 @@ test('shows generated details on success', async () => {
       expect(body).toEqual({ url: 'https://example.com', cms: [] })
       return Response.json({
         result: {
-          personas: { p1: { name: 'P1' } },
-          insight: { report: 'Flow' },
+          personas: { p1: { name: 'P1', role: 'buyer' } },
+          insight: 'Flow',
+          actions: [
+            { persona: 'p1', description: 'Do it', evidence: ['src'] },
+          ],
         },
       })
     }),
@@ -177,8 +180,11 @@ test('shows generated details on success', async () => {
   await screen.findByText('Test insight')
   const btn = screen.getByRole('button', { name: /generate insights/i })
   await userEvent.click(btn)
-  await screen.findByText('P1')
+  await screen.findByText('Do it')
   screen.getByText('Flow')
+  screen.getByText('src')
+  screen.getByText('P1')
+  screen.getByText('buyer')
 })
 
 test('shows error when generation fails', async () => {

--- a/interface/src/components/InsightCard.suite.test.tsx
+++ b/interface/src/components/InsightCard.suite.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import { describe, test } from 'vitest'
+import InsightCard from './InsightCard'
+import type { ParsedInsight } from '../utils/insightParser'
+
+describe('InsightCard', () => {
+  test('renders summary, actions and personas', () => {
+    const insight: ParsedInsight = {
+      summary: 'My summary',
+      personas: [{ id: 'p1', name: 'P1', role: 'buyer' }],
+      actions: [
+        { description: 'Do it', persona: 'p1', evidence: ['src'] },
+        { description: 'Another' },
+      ],
+    }
+    render(<InsightCard insight={insight} />)
+    screen.getByText('My summary')
+    screen.getByText('Do it')
+    screen.getByText('Another')
+    screen.getByText('src')
+    screen.getByText('P1')
+    screen.getByText('buyer')
+  })
+
+  test('falls back to persona id when name missing', () => {
+    const insight: ParsedInsight = {
+      summary: '',
+      personas: [{ id: 'p1' }],
+      actions: [{ description: 'Thing', persona: 'p1' }],
+    }
+    render(<InsightCard insight={insight} />)
+    screen.getByText('p1:')
+    screen.getByText('Thing')
+  })
+})


### PR DESCRIPTION
## Summary
- expand AnalyzerCard test to expect generated insight content
- add InsightCard.suite.test.tsx to cover fallback cases

## Testing
- `npx --yes vitest run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68883d555054832997bc9b0f153c72d0