### PR TITLE
Include cms_manual and degraded flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The gateway orchestrates the other APIs. Key endpoints:
 * `POST /analyze` – body `{"url": "https://example.com", "headless": false, "force": false}` returns:
   `{"property": {...}, "martech": {...}}`.
 * `POST /generate` – body `{"url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress"}` proxies to the insight service and returns persona and insight JSON.
-* `POST /generate-insight-and-personas` – body `{"url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress"}` proxies to the insight service and returns `{"insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}]}`. The gateway performs both OpenAI calls concurrently and enforces a 20 s timeout.
+* `POST /generate-insight-and-personas` – body `{"url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress"}` proxies to the insight service and returns `{"insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false}`. The gateway performs both OpenAI calls concurrently and enforces a 20 s timeout.
 * `INSIGHT_TIMEOUT` controls how long the gateway waits for an insight reply (default `20`s).
 
 Request schema:
@@ -226,7 +226,7 @@ Endpoints:
 * `POST /generate-insights` – body `{"text": "your notes"}` returns `{"insight": "..."}`.
 * `POST /research` – body `{"topic": "AI"}` returns `{"summary": "..."}`.
 * `POST /postprocess-report` – body `{"report": {...}}` returns downloads with markdown and CSV.
-* `POST /insight-and-personas` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress" }` returns `{ "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}] }`. This endpoint runs the insight and persona prompts concurrently for faster replies.
+* `POST /insight-and-personas` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress" }` returns `{ "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false }`. This endpoint runs the insight and persona prompts concurrently for faster replies.
 
 Set `OPENAI_MODEL` to choose the chat model (default `gpt-4`).
 Set `MACRO_SECTION_CAP` to cap macro sections returned by `/research`.

--- a/services/insight/README.md
+++ b/services/insight/README.md
@@ -12,7 +12,7 @@ It runs at `http://localhost:8083` when using Docker Compose.
 - `POST /postprocess-report` – body `{ "report": {...} }` returns the same report
   plus base64-encoded downloads.
 - `POST /insight-and-personas` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress" }`
-  returns { "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}] }. Insight and persona prompts run concurrently. The gateway will return a timeout after 20s if the insight service is slow.
+  returns { "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false }. Insight and persona prompts run concurrently. The gateway will return a timeout after 20s if the insight service is slow.
 - `GET /metrics` – usage counters for requests and data gaps.
 
 ## Environment variables
@@ -50,6 +50,8 @@ Expected response snippet:
 ```json
 {
   "insight": { "actions": [], "evidence": "..." },
-  "personas": [{"id": "P1"}]
+  "personas": [{"id": "P1"}],
+  "cms_manual": "WordPress",
+  "degraded": false
 }
 ```

--- a/services/insight/app.py
+++ b/services/insight/app.py
@@ -383,10 +383,21 @@ async def insight_and_personas(req: InsightPersonaRequest) -> JSONResponse:
 
         insight_obj = {"actions": actions, "evidence": insight_text}
 
+        degraded = False
+        if (
+            isinstance(insight_raw, dict) and insight_raw.get("error") == "[Data Gap]"
+        ) or (
+            isinstance(personas_raw, dict) and personas_raw.get("error") == "[Data Gap]"
+        ):
+            degraded = True
+
         result = {
             "insight": insight_obj,
             "personas": personas_list,
+            "degraded": degraded,
         }
+        if req.cms_manual:
+            result["cms_manual"] = req.cms_manual
         _append_size_warning(result)
         duration = time.perf_counter() - start
         scope = len(json.dumps(req.model_dump()))

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -216,7 +216,7 @@ def test_insight_and_personas(monkeypatch):
     assert data["insight"] == {"actions": [], "evidence": "I"}
     assert data["personas"] == [{"id": "P1", "name": "P1"}]
     assert "cms_manual" not in data
-    assert "degraded" not in data
+    assert data["degraded"] is False
 
     metrics_data = client.get("/metrics").json()
     assert metrics_data["insight-and-personas"]["requests"] == before + 1
@@ -243,7 +243,7 @@ def test_insight_and_personas_warnings(monkeypatch):
     assert result["insight"] == {"actions": [], "evidence": {"data": huge}}
     assert result["personas"] == []
     assert "cms_manual" not in result
-    assert "degraded" not in result
+    assert result["degraded"] is False
     assert "warnings" in result.get("meta", {})
 
     metrics_data = client.get("/metrics").json()


### PR DESCRIPTION
## Summary
- return `cms_manual` and `degraded` in /insight-and-personas
- expect these fields in insight API tests
- document the updated schema in service README and root README

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888e48ecfe4832991351c352e1139c1