### PR TITLE
Add typography plugin

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@storybook/react": "^9.0.18",
+        "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -2507,6 +2508,36 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "storybook": "^9.0.18"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -5622,6 +5653,20 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
       "license": "MIT"
     },

--- a/interface/package.json
+++ b/interface/package.json
@@ -42,6 +42,7 @@
     "msw": "^2.4.9",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.4",
+    "@tailwindcss/typography": "^0.5.16",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4",

--- a/interface/src/components/InsightCard.tsx
+++ b/interface/src/components/InsightCard.tsx
@@ -65,9 +65,7 @@ export default function InsightCard({ insight }: InsightCardProps) {
       )}
       {evidence && (
         <CardContent>
-          <div className="prose max-w-none">
-            <p>{evidence}</p>
-          </div>
+          <p className="prose max-w-none">{evidence}</p>
         </CardContent>
       )}
       {actions.length > 0 && (

--- a/interface/tailwind.config.js
+++ b/interface/tailwind.config.js
@@ -1,3 +1,5 @@
+import typography from '@tailwindcss/typography'
+
 export default {
   content: [
     './index.html',
@@ -35,5 +37,5 @@ export default {
       }
     },
   },
-  plugins: [],
+  plugins: [typography],
 }


### PR DESCRIPTION
## Summary
- install `@tailwindcss/typography`
- enable typography plugin in Tailwind config
- style InsightCard evidence text with `.prose`

## Testing
- `npm --prefix interface test`
- `tox -e py`


------
https://chatgpt.com/codex/tasks/task_e_688930ce5c8083299af267cc602aa761