### PR TITLE
Remove python_paths from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
 addopts = -q
-python_paths = services


### PR DESCRIPTION
## Summary
- drop deprecated `python_paths` option from `pytest.ini`

## Testing
- `PYTHONPATH=services pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68896a9d5f7c8329b126aa0f4f7a36fd