### PR TITLE
Implement org context for insights

### DIFF
--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -5,6 +5,7 @@ import { http } from 'msw'
 import { test, expect } from 'vitest'
 import type { AnalyzeResult } from './AnalyzerCard'
 import { computeMartechCount } from './AnalyzerCard'
+import { ORG_CONTEXT } from '../config/orgContext'
 
 test('shows spinner when loading', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
@@ -179,7 +180,12 @@ test('shows generated details on success', async () => {
   server.use(
     http.post('/generate-insight-and-personas', async ({ request }) => {
       const body = await request.json()
-      expect(body).toEqual({ url: 'https://example.com', cms: [] })
+      expect(body).toEqual({
+        url: 'https://example.com',
+        martech: result.martech,
+        cms: [],
+        ...ORG_CONTEXT,
+      })
       return Response.json({
         result: {
           insight: {

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -6,6 +6,7 @@ import InsightCard from './InsightCard'
 import { apiFetch } from '../api'
 import { normalizeUrl, downloadBase64 } from '../utils'
 import { parseInsightPayload, type ParsedInsight } from '../utils/insightParser'
+import { ORG_CONTEXT } from '../config/orgContext'
 
 export function computeMartechCount(
   martech: Record<string, string[] | Record<string, unknown>> | null,
@@ -117,8 +118,10 @@ export default function AnalyzerCard({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           url: clean,
+          martech: result.martech,
           cms: result.cms || [],
           ...(manualCms ? { cms_manual: manualCms } : {}),
+          ...ORG_CONTEXT,
         }),
       })
       setParsedInsight(parseInsightPayload(data.result))

--- a/interface/src/config/orgContext.ts
+++ b/interface/src/config/orgContext.ts
@@ -1,0 +1,7 @@
+export const ORG_CONTEXT = {
+  evidence_standards: "Use peer-reviewed data or ...",
+  credibility_scoring: "Unitron's scoring = ...",
+  deliverable_guidelines: "Follow the PRD deliverable format v2.1",
+  audience: "Mid-market SaaS VPs of Ops …",
+  preferences: "Prefer bullet lists; US English",
+};

--- a/services/insight/app.py
+++ b/services/insight/app.py
@@ -104,6 +104,11 @@ class InsightPersonaRequest(BaseModel):
     martech: dict[str, list[str]] | None = None
     cms: list[str] | None = None
     cms_manual: str | None = None
+    evidence_standards: str | None = None
+    credibility_scoring: str | None = None
+    deliverable_guidelines: str | None = None
+    audience: str | None = None
+    preferences: str | None = None
 
 
 def _validate_with_schema(data: dict, model: type[BaseModel]) -> BaseModel:
@@ -338,12 +343,22 @@ async def insight_and_personas(req: InsightPersonaRequest) -> JSONResponse:
         "Generate next-best-action insights.",
         company=company,
         technology=tech,
+        evidence_standards=req.evidence_standards,
+        credibility_scoring=req.credibility_scoring,
+        deliverable_guidelines=req.deliverable_guidelines,
+        audience=req.audience,
+        preferences=req.preferences,
     )
 
     persona_prompt = orchestrator.build_prompt(
         "Generate buyer personas.",
         company=company,
         technology=tech,
+        evidence_standards=req.evidence_standards,
+        credibility_scoring=req.credibility_scoring,
+        deliverable_guidelines=req.deliverable_guidelines,
+        audience=req.audience,
+        preferences=req.preferences,
     )
 
     try:
@@ -388,6 +403,17 @@ async def insight_and_personas(req: InsightPersonaRequest) -> JSONResponse:
             isinstance(insight_raw, dict) and insight_raw.get("error") == "[Data Gap]"
         ) or (
             isinstance(personas_raw, dict) and personas_raw.get("error") == "[Data Gap]"
+        ):
+            degraded = True
+        if any(
+            field is None
+            for field in (
+                req.evidence_standards,
+                req.credibility_scoring,
+                req.deliverable_guidelines,
+                req.audience,
+                req.preferences,
+            )
         ):
             degraded = True
 

--- a/services/insight/orchestrator.py
+++ b/services/insight/orchestrator.py
@@ -13,42 +13,33 @@ except Exception:  # noqa: BLE001
 
 logger = logging.getLogger(__name__)
 
-EVIDENCE_STANDARDS = (
-    "[Data Gap] Evidence standards from PRD are unavailable."
-)
-SCORING_FORMULA = (
-    "[Data Gap] Credibility scoring formula from PRD is unavailable."
-)
-DELIVERABLE_GUIDELINES = (
-    "[Data Gap] Deliverable guidelines from PRD are unavailable."
-)
-
 
 def build_prompt(
     question: str,
-    audience: str | None = None,
-    prefs: dict[str, Any] | None = None,
+    *,
     company: dict[str, Any] | None = None,
     technology: dict[str, Any] | None = None,
+    evidence_standards: str | None = None,
+    credibility_scoring: str | None = None,
+    deliverable_guidelines: str | None = None,
+    audience: str | None = None,
+    preferences: str | None = None,
 ) -> str:
-    """Return a prompt for the OpenAI model.
+    """Return a prompt for the OpenAI model."""
 
-    The prompt references evidence standards, credibility scoring and
-    deliverable guidelines from the PRD. Missing sections are flagged with
-    ``[Data Gap]``.
-    """
-
-    audience_text = audience or "[Data Gap]"
-    pref_parts = [f"{k}: {v}" for k, v in (prefs or {}).items()]
-    prefs_text = "; ".join(pref_parts) if pref_parts else "[Data Gap]"
-    company_text = json.dumps(company) if company else "[Data Gap]"
-    tech_text = json.dumps(technology) if technology else "[Data Gap]"
+    evidence_text = evidence_standards or ""
+    scoring_text = credibility_scoring or ""
+    guidelines_text = deliverable_guidelines or ""
+    audience_text = audience or ""
+    prefs_text = preferences or ""
+    company_text = json.dumps(company) if company else ""
+    tech_text = json.dumps(technology) if technology else ""
 
     prompt = (
         "You are the Unitron insight orchestrator.\n"
-        f"Adhere to the following evidence standards:\n{EVIDENCE_STANDARDS}\n"
-        f"Apply the credibility scoring formula:\n{SCORING_FORMULA}\n"
-        f"Follow these deliverable guidelines:\n{DELIVERABLE_GUIDELINES}\n"
+        f"Adhere to the following evidence standards:\n{evidence_text}\n"
+        f"Apply the credibility scoring formula:\n{scoring_text}\n"
+        f"Follow these deliverable guidelines:\n{guidelines_text}\n"
         f"Audience: {audience_text}\n"
         f"Preferences: {prefs_text}\n"
         f"Company: {company_text}\n"

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -209,7 +209,16 @@ def test_insight_and_personas(monkeypatch):
 
     r = client.post(
         "/insight-and-personas",
-        json={"url": "https://ex", "martech": {}, "cms": ["WP"]},
+        json={
+            "url": "https://ex",
+            "martech": {},
+            "cms": ["WP"],
+            "evidence_standards": "std",
+            "credibility_scoring": "score",
+            "deliverable_guidelines": "guidelines",
+            "audience": "devs",
+            "preferences": "none",
+        },
     )
     assert r.status_code == 200
     data = r.json()
@@ -243,7 +252,7 @@ def test_insight_and_personas_warnings(monkeypatch):
     assert result["insight"] == {"actions": [], "evidence": {"data": huge}}
     assert result["personas"] == []
     assert "cms_manual" not in result
-    assert result["degraded"] is False
+    assert result["degraded"] is True
     assert "warnings" in result.get("meta", {})
 
     metrics_data = client.get("/metrics").json()


### PR DESCRIPTION
## Summary
- extend `InsightPersonaRequest` with context fields
- include context when building prompts
- forward context from analyzer UI via new `ORG_CONTEXT`
- adjust degraded flag logic when context missing
- update tests for new request schema

## Testing
- `make lint`
- `make test`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68896f27b7848329a6d962b069a1ab55