### PR TITLE
Fix org context fields for insight

### DIFF
--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -184,7 +184,11 @@ test('shows generated details on success', async () => {
         url: 'https://example.com',
         martech: result.martech,
         cms: [],
-        ...ORG_CONTEXT,
+        evidence_standards: ORG_CONTEXT.evidence_standards ?? '',
+        credibility_scoring: ORG_CONTEXT.credibility_scoring ?? '',
+        deliverable_guidelines: ORG_CONTEXT.deliverable_guidelines ?? '',
+        audience: ORG_CONTEXT.audience ?? '',
+        preferences: ORG_CONTEXT.preferences ?? '',
       })
       return Response.json({
         result: {

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -121,7 +121,11 @@ export default function AnalyzerCard({
           martech: result.martech,
           cms: result.cms || [],
           ...(manualCms ? { cms_manual: manualCms } : {}),
-          ...ORG_CONTEXT,
+          evidence_standards: ORG_CONTEXT.evidence_standards ?? '',
+          credibility_scoring: ORG_CONTEXT.credibility_scoring ?? '',
+          deliverable_guidelines: ORG_CONTEXT.deliverable_guidelines ?? '',
+          audience: ORG_CONTEXT.audience ?? '',
+          preferences: ORG_CONTEXT.preferences ?? '',
         }),
       })
       setParsedInsight(parseInsightPayload(data.result))


### PR DESCRIPTION
## Summary
- explicitly set org context fields in `onGenerate`
- update tests for explicit org context payload

## Testing
- `make lint`
- `make test`
- `npm test` in `interface`

------
https://chatgpt.com/codex/tasks/task_e_68897505a95c832992e1a74089450fdc