### PR TITLE
Fix degraded check when fields empty

### DIFF
--- a/services/insight/app.py
+++ b/services/insight/app.py
@@ -421,7 +421,7 @@ async def insight_and_personas(req: InsightPersonaRequest) -> JSONResponse:
         ):
             degraded = True
         if any(
-            field is None
+            field in (None, "")
             for field in (
                 req.evidence_standards,
                 req.credibility_scoring,

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -231,6 +231,36 @@ def test_insight_and_personas(monkeypatch):
     assert metrics_data["insight-and-personas"]["requests"] == before + 1
 
 
+def test_insight_and_personas_empty_fields(monkeypatch):
+    async def fake_report(prompt: str, **_kwargs):
+        if "buyer personas" in prompt.lower():
+            return {"generated_buyer_personas": {"P1": {"name": "P1"}}}
+        return {"report": "I"}
+
+    monkeypatch.setattr(
+        insight_mod.orchestrator,
+        "generate_report",
+        fake_report,
+    )
+
+    r = client.post(
+        "/insight-and-personas",
+        json={
+            "url": "https://ex",
+            "martech": {},
+            "cms": ["WP"],
+            "evidence_standards": "",
+            "credibility_scoring": "",
+            "deliverable_guidelines": "",
+            "audience": "",
+            "preferences": "",
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["degraded"] is True
+
+
 def test_insight_and_personas_warnings(monkeypatch):
     huge = "[Data Gap]" + "x" * (260 * 1024)
 


### PR DESCRIPTION
## Summary
- mark `insight-and-personas` responses as degraded when optional text fields are empty strings
- test that empty strings trigger degraded state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897b3ae89083298b638df696ba53f3