### PR TITLE
Normalize martech payload

### DIFF
--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -182,7 +182,12 @@ test('shows generated details on success', async () => {
       const body = await request.json()
       expect(body).toEqual({
         url: 'https://example.com',
-        martech: result.martech,
+        martech: {
+          core: (result.martech as any)?.core ?? [],
+          adjacent: (result.martech as any)?.adjacent ?? [],
+          broader: (result.martech as any)?.broader ?? [],
+          competitors: (result.martech as any)?.competitors ?? [],
+        },
         cms: [],
         evidence_standards: ORG_CONTEXT.evidence_standards ?? '',
         credibility_scoring: ORG_CONTEXT.credibility_scoring ?? '',

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -113,12 +113,18 @@ export default function AnalyzerCard({
     setGenError(null)
     try {
       const clean = normalizeUrl(url)
+      const martech = {
+        core: (result.martech as any)?.core ?? [],
+        adjacent: (result.martech as any)?.adjacent ?? [],
+        broader: (result.martech as any)?.broader ?? [],
+        competitors: (result.martech as any)?.competitors ?? [],
+      }
       const data = await apiFetch<{ result: unknown }>('/generate-insight-and-personas', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           url: clean,
-          martech: result.martech,
+          martech,
           cms: result.cms || [],
           ...(manualCms ? { cms_manual: manualCms } : {}),
           evidence_standards: ORG_CONTEXT.evidence_standards ?? '',


### PR DESCRIPTION
## Summary
- normalize martech buckets before calling generate-insight API
- update AnalyzerCard tests to expect normalized martech object

## Testing
- `npm test --silent`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6889843c84988329a8fd4badca9ed0bd