### PR TITLE
Update docs for optional insight fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The gateway orchestrates the other APIs. Key endpoints:
 * `POST /analyze` – body `{"url": "https://example.com", "headless": false, "force": false}` returns:
   `{"property": {...}, "martech": {...}}`.
 * `POST /generate` – body `{"url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress"}` proxies to the insight service and returns persona and insight JSON.
-* `POST /generate-insight-and-personas` – body `{"url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress"}` proxies to the insight service and returns `{"insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false}`. The gateway performs both OpenAI calls concurrently and enforces a 20 s timeout.
+* `POST /generate-insight-and-personas` – body `{"url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress", "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS"}` proxies to the insight service and returns `{"insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false}`. The gateway performs both OpenAI calls concurrently and enforces a 20 s timeout.
 * `INSIGHT_TIMEOUT` controls how long the gateway waits for an insight reply (default `20`s).
 
 Request schema:
@@ -106,7 +106,12 @@ Request schema:
   "url": "https://example.com",
   "martech": {},
   "cms": [],
-  "cms_manual": "WordPress"
+  "cms_manual": "WordPress",
+  "evidence_standards": "Use peer-reviewed data when available",
+  "credibility_scoring": "Score evidence 1-5 based on reliability",
+  "deliverable_guidelines": "Write deliverables in plain language",
+  "audience": "CTO and senior engineers",
+  "preferences": "Focus on open-source solutions"
 }
 ```
 
@@ -137,7 +142,7 @@ Example (generate with manual CMS):
 ```bash
 curl -X POST http://localhost:8080/generate-insight-and-personas \
   -H 'Content-Type: application/json' \
-  -d '{"url": "https://example.com", "martech": {}, "cms": [], "cms_manual": "WordPress"}'
+  -d '{"url": "https://example.com", "martech": {}, "cms": [], "cms_manual": "WordPress", "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS"}'
 ```
 
 ### Martech analyzer service
@@ -219,9 +224,11 @@ python‑wappalyzer. It is disabled by default to keep startup fast.
 ### Manual CMS input
 
 The `/generate-insight-and-personas` endpoint lets you provide a `cms_manual` string when the
-analyzer cannot detect a CMS. The gateway forwards this value to the martech
-service which in turn calls the insight service so personas can still reference
-a specific platform.
+analyzer cannot detect a CMS. Optional keys `evidence_standards`, `credibility_scoring`,
+`deliverable_guidelines`, `audience` and `preferences` customize how the insight
+service writes the report. The gateway forwards these values to the martech service
+which in turn calls the insight service so personas can still reference a specific
+platform and follow your guidelines.
 
 The React interface exposes a dropdown for this field only when the analysis
 returns an empty CMS list.
@@ -231,7 +238,7 @@ Example request:
 ```bash
 curl -X POST http://localhost:8080/generate-insight-and-personas \
   -H 'Content-Type: application/json' \
-  -d '{"url": "https://example.com", "martech": {}, "cms": [], "cms_manual": "Drupal"}'
+  -d '{"url": "https://example.com", "martech": {}, "cms": [], "cms_manual": "Drupal", "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS"}'
 ```
 
 Set `CMS_MANUAL_LOG_PATH` to a file path to record submitted `cms_manual`

--- a/services/insight/README.md
+++ b/services/insight/README.md
@@ -11,8 +11,8 @@ It runs at `http://localhost:8083` when using Docker Compose.
 - `POST /research` – body `{ "topic": "AI" }` returns `{ "summary": "..." }`.
 - `POST /postprocess-report` – body `{ "report": {...} }` returns the same report
   plus base64-encoded downloads.
-- `POST /insight-and-personas` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress" }`
-  returns { "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false }. Insight and persona prompts run concurrently. The gateway will return a timeout after 20s if the insight service is slow.
+- `POST /insight-and-personas` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress", "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS" }`
+  returns { "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false }. Insight and persona prompts run concurrently. The gateway will return a timeout after 20s if the insight service is slow. The optional fields fine‑tune how the report is generated.
 - `GET /metrics` – usage counters for requests and data gaps.
 
 ## Environment variables
@@ -63,7 +63,7 @@ Example (insight and personas):
 ```bash
 curl -X POST http://localhost:8083/insight-and-personas \
   -H 'Content-Type: application/json' \
-  -d '{"url": "https://example.com", "martech": {}, "cms": [], "cms_manual": "WordPress"}'
+  -d '{"url": "https://example.com", "martech": {}, "cms": [], "cms_manual": "WordPress", "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS"}'
 ```
 
 Expected response snippet:


### PR DESCRIPTION
## Summary
- update endpoint description for `/generate-insight-and-personas`
- document `evidence_standards`, `credibility_scoring`, `deliverable_guidelines`, `audience` and `preferences`
- show new fields in request schema and example curl commands

## Testing
- `make lint` *(fails: E303 too many blank lines in tests/test_insight.py)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6889854dd84c8329a07d1deb1f379ff3