### PR TITLE
Add request schema and include zod

### DIFF
--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -42,7 +42,8 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.35.1",
         "vite": "^7.0.4",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.4",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -8321,6 +8322,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/interface/package.json
+++ b/interface/package.json
@@ -46,6 +46,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "zod": "^3.23.8"
   }
 }

--- a/interface/src/utils/requestSchema.ts
+++ b/interface/src/utils/requestSchema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+export const requestSchema = z.object({
+  url: z.string().url(),
+  martech: z.object({
+    core: z.array(z.string()),
+    adjacent: z.array(z.string()),
+    broader: z.array(z.string()),
+    competitors: z.array(z.string()),
+  }),
+  cms: z.array(z.string()),
+  evidence_standards: z.string().max(1024),
+  credibility_scoring: z.string().max(1024),
+  deliverable_guidelines: z.string().max(1024),
+  audience: z.string().max(1024),
+  preferences: z.string().max(1024),
+})
+
+export type RequestSchema = z.infer<typeof requestSchema>


### PR DESCRIPTION
## Summary
- add zod-based request schema
- export schema and inferred type
- install zod as dev dependency

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6889947457f48329a94034c35ae3b162