### PR TITLE
Add OpenAI retry helper with degraded flag

### DIFF
--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -40,11 +40,14 @@ def test_generate_insights(monkeypatch):
 
     dummy_module = types.SimpleNamespace(AsyncOpenAI=lambda api_key=None: DummyClient())
     monkeypatch.setattr(insight_mod, "openai", dummy_module, raising=False)
+    monkeypatch.setattr(insight_mod.orchestrator, "openai", dummy_module, raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
 
     r = client.post("/generate-insights", json={"text": "  some text\n"})
     assert r.status_code == 200
-    assert r.json()["insight"] == "Hello insight"
+    data = r.json()
+    assert data["insight"] == "Hello insight"
+    assert data["degraded"] is False
 
 
 def test_research(monkeypatch):
@@ -65,11 +68,14 @@ def test_research(monkeypatch):
 
     dummy_module = types.SimpleNamespace(AsyncOpenAI=lambda api_key=None: DummyClient())
     monkeypatch.setattr(insight_mod, "openai", dummy_module, raising=False)
+    monkeypatch.setattr(insight_mod.orchestrator, "openai", dummy_module, raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
 
     r = client.post("/research", json={"topic": "AI"})
     assert r.status_code == 200
-    assert r.json()["summary"] == "Research result"
+    data = r.json()
+    assert data["summary"] == "Research result"
+    assert data["degraded"] is False
 
 
 def test_research_trim(monkeypatch):
@@ -92,11 +98,14 @@ def test_research_trim(monkeypatch):
         AsyncOpenAI=lambda api_key=None: DummyClient(),
     )
     monkeypatch.setattr(insight_mod, "openai", dummy_module, raising=False)
+    monkeypatch.setattr(insight_mod.orchestrator, "openai", dummy_module, raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
 
     r = client.post("/research", json={"topic": "AI"})
     assert r.status_code == 200
-    assert r.json()["summary"] == "Trim me"
+    data = r.json()
+    assert data["summary"] == "Trim me"
+    assert data["degraded"] is False
 
 
 def test_research_validation_error():
@@ -181,6 +190,7 @@ def test_metrics_and_warnings(monkeypatch):
 
     dummy_module = types.SimpleNamespace(AsyncOpenAI=lambda api_key=None: DummyClient())
     monkeypatch.setattr(insight_mod, "openai", dummy_module, raising=False)
+    monkeypatch.setattr(insight_mod.orchestrator, "openai", dummy_module, raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
 
     r = client.post("/generate-insights", json={"text": "info"})

--- a/tests/test_insight_retry.py
+++ b/tests/test_insight_retry.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+import types
+
+from services.insight.app import app
+import services.insight.app as insight_mod
+
+client = TestClient(app)
+
+
+def test_retry_rate_limit(monkeypatch):
+    class DummyResp:
+        def __init__(self, content: str) -> None:
+            message_obj = type("obj", (), {"content": content})()
+            self.choices = [type("obj", (), {"message": message_obj})()]
+
+    class RateLimitErr(Exception):
+        def __init__(self) -> None:
+            self.status_code = 429
+
+    attempts = {"n": 0}
+
+    async def fake_create(**_kwargs):
+        if attempts["n"] < 2:
+            attempts["n"] += 1
+            raise RateLimitErr()
+        return DummyResp("ok")
+
+    class DummyChat:
+        completions = type("obj", (), {"create": staticmethod(fake_create)})()
+
+    class DummyClient:
+        def __init__(self, *a, **kw) -> None:
+            self.chat = DummyChat
+
+    dummy_module = types.SimpleNamespace(AsyncOpenAI=lambda api_key=None: DummyClient())
+    monkeypatch.setattr(insight_mod, "openai", dummy_module, raising=False)
+    monkeypatch.setattr(insight_mod.orchestrator, "openai", dummy_module, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    r = client.post("/generate-insights", json={"text": "hi"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["insight"] == "ok"
+    assert data["degraded"] is False


### PR DESCRIPTION
## Summary
- add `call_openai_with_retry` for shared OpenAI logic
- use it in the insight service endpoints
- surface `degraded` flag in generate-insights and research
- test retry behaviour and adjust existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889b52237348329967e245bf0492583