### PR TITLE
Enable CORS and security headers

### DIFF
--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -12,6 +12,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse
 from fastapi.middleware.cors import CORSMiddleware
+from services.shared import SecurityHeadersMiddleware
 from pydantic import BaseModel, model_validator
 from starlette.responses import JSONResponse
 
@@ -30,14 +31,13 @@ app = FastAPI(lifespan=lifespan)
 # Allow calls from the UI hosted on a different origin during development
 # UI_ORIGIN should contain the frontend domain
 # (e.g. http://localhost:5173)
-origins = [os.getenv("UI_ORIGIN", "*")]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
+    allow_origins=["*"],
     allow_methods=["*"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type", "Authorization"],
 )
+app.add_middleware(SecurityHeadersMiddleware)
 
 # Default service URLs used in local docker-compose
 MARTECH_URL = os.getenv("MARTECH_URL", "http://martech:8000")

--- a/services/insight/app.py
+++ b/services/insight/app.py
@@ -8,6 +8,7 @@ import time
 import asyncio
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from services.shared import SecurityHeadersMiddleware
 from contextlib import asynccontextmanager
 import httpx
 from pydantic import BaseModel, ValidationError, Field
@@ -40,14 +41,13 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-origins = [os.getenv("UI_ORIGIN", "*")]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
+    allow_origins=["*"],
     allow_methods=["*"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type", "Authorization"],
 )
+app.add_middleware(SecurityHeadersMiddleware)
 
 logger = logging.getLogger(__name__)
 

--- a/services/martech/app.py
+++ b/services/martech/app.py
@@ -13,6 +13,7 @@ from bs4 import BeautifulSoup
 from fastapi import FastAPI, HTTPException
 from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
+from services.shared import SecurityHeadersMiddleware
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 from services.shared.utils import detect_vendors
@@ -58,14 +59,13 @@ app = FastAPI(lifespan=lifespan)
 # Allow calls from the UI hosted on a different origin during development
 # UI_ORIGIN should contain the frontend domain
 # (e.g. http://localhost:5173)
-origins = [os.getenv("UI_ORIGIN", "*")]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
+    allow_origins=["*"],
     allow_methods=["*"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type", "Authorization"],
 )
+app.add_middleware(SecurityHeadersMiddleware)
 
 # Global state populated on startup
 try:

--- a/services/property/app.py
+++ b/services/property/app.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import os
 from urllib.parse import urlparse
 import socket
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException
 import httpx
 from fastapi.middleware.cors import CORSMiddleware
+from services.shared import SecurityHeadersMiddleware
 from pydantic import BaseModel
 from services.shared.utils import normalize_url
 from starlette.responses import JSONResponse
@@ -26,14 +26,13 @@ app = FastAPI(lifespan=lifespan)
 # Allow web interface to call this API from another origin during development
 # UI_ORIGIN should contain the frontend domain
 # (e.g. http://localhost:5173)
-origins = [os.getenv("UI_ORIGIN", "*")]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
+    allow_origins=["*"],
     allow_methods=["*"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type", "Authorization"],
 )
+app.add_middleware(SecurityHeadersMiddleware)
 
 
 class RawAnalyzeRequest(BaseModel):

--- a/services/shared/__init__.py
+++ b/services/shared/__init__.py
@@ -1,0 +1,1 @@
+from .security import SecurityHeadersMiddleware

--- a/services/shared/security.py
+++ b/services/shared/security.py
@@ -1,0 +1,12 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Inject basic security headers into each response."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+        response = await call_next(request)
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        return response

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -158,6 +158,23 @@ def test_analyze_degraded_when_service_unready(monkeypatch):
     assert data["cms"] == []
 
 
+def test_options_analyze():
+    r = client.options(
+        "/analyze",
+        headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers["access-control-allow-origin"] == "*"
+    allowed = r.headers["access-control-allow-headers"]
+    assert "Content-Type" in allowed
+    assert "Authorization" in allowed
+    assert r.headers["x-frame-options"] == "DENY"
+    assert r.headers["x-content-type-options"] == "nosniff"
+
+
 def test_metrics_endpoint(monkeypatch):
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200)

--- a/tests/test_martech.py
+++ b/tests/test_martech.py
@@ -113,6 +113,12 @@ def test_options_analyze():
         },
     )
     assert r.status_code == 200
+    assert r.headers['access-control-allow-origin'] == '*'
+    allowed = r.headers['access-control-allow-headers']
+    assert 'Content-Type' in allowed
+    assert 'Authorization' in allowed
+    assert r.headers['x-frame-options'] == 'DENY'
+    assert r.headers['x-content-type-options'] == 'nosniff'
 
 
 def test_analyze_handles_request_error(monkeypatch):

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -44,3 +44,9 @@ def test_options_analyze():
         },
     )
     assert r.status_code == 200
+    assert r.headers["access-control-allow-origin"] == "*"
+    allowed = r.headers["access-control-allow-headers"]
+    assert "Content-Type" in allowed
+    assert "Authorization" in allowed
+    assert r.headers["x-frame-options"] == "DENY"
+    assert r.headers["x-content-type-options"] == "nosniff"


### PR DESCRIPTION
## Summary
- allow any origin for CORS and restrict accepted headers
- inject common security headers for all services
- test that OPTIONS preflight succeeds and headers are present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a4f75418c8329997b998604881ff5