### PR TITLE
Add Playwright happy path test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,17 @@ jobs:
         run: docker build -t property-image -f Dockerfile .
       - name: Verify npx exists
         run: docker run --rm interface-image which npx
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: playwright/package-lock.json
+      - name: Install Playwright dependencies
+        run: npm ci
+        working-directory: playwright
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+        working-directory: playwright
+      - name: Run Playwright tests
+        run: npx playwright test
+        working-directory: playwright

--- a/playwright/insight-happy.spec.ts
+++ b/playwright/insight-happy.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+test('insight happy path shows actions', async ({ page }) => {
+  await page.route('**/ready', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ ready: true })
+  }));
+
+  await page.route('**/analyze', async route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        property: { domains: ['example.com'], confidence: 1, notes: [] },
+        martech: { core: ['GTM'] },
+        cms: [],
+        degraded: false
+      })
+    });
+  });
+
+  await page.route('**/insight', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ result: { insight: 'Test insight' } })
+  }));
+
+  await page.route('**/postprocess-report', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ downloads: {} })
+  }));
+
+  await page.route('**/generate-insight-and-personas', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      result: {
+        insight: {
+          evidence: 'Flow',
+          actions: { a1: { title: 'Do it', reasoning: 'why', benefit: 'gain' } }
+        },
+        personas: { p1: { name: 'P1' } },
+        degraded: false
+      }
+    })
+  }));
+
+  await page.goto('/');
+  await page.fill('input[aria-label="URL to analyze"]', 'example.com');
+  await page.click('button[aria-label="analyze"]');
+
+  await page.getByText('example.com');
+  await page.getByRole('button', { name: /generate insights/i }).click();
+
+  const actions = page.locator('button:has-text("Do it")');
+  await expect(actions).toHaveCount(1);
+});

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "playwright",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "playwright",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.54.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
+      "integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "playwright",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.54.1"
+  }
+}

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  webServer: {
+    command: 'npm run dev -- --port 5173',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    cwd: '../interface'
+  },
+});


### PR DESCRIPTION
## Summary
- create Playwright project under `playwright/`
- add `insight-happy.spec.ts` that verifies insights actions render
- configure Playwright to launch the dev server
- run Playwright tests in CI workflow

## Testing
- `poetry run bash -c 'PYTHONPATH=services pytest -q'`
- `npx playwright install --with-deps` *(fails: domain forbidden)*
- `npx playwright test insight-happy.spec.ts` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a5b90d1f48329994b9bbc077d6d45