### PR TITLE
Ignore Playwright node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 
 # Node
 interface/node_modules/
+playwright/node_modules/


### PR DESCRIPTION
## Summary
- keep Playwright deps out of version control by ignoring `playwright/node_modules/`

## Testing
- `make lint` *(fails: F401 '.security.SecurityHeadersMiddleware' imported but unused)*
- `make test` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_688a7a17dc8883299bc889f133b2c2d6