### PR TITLE
Add Playwright test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,17 @@ To verify that the gateway service is reachable, export `GATEWAY_URL` and execut
 GATEWAY_URL=http://localhost:8080 ./test-gateway.sh
 ```
 
+### Playwright tests
+
+Node 18 is used for the end-to-end browser tests. Install the frontend and
+Playwright dependencies and then run the suite:
+
+```bash
+npm ci --prefix interface
+npm ci --prefix playwright
+npx playwright test
+```
+
 ## FAQ
 
 **Why Docker instead of running Python directly?**

--- a/services/shared/__init__.py
+++ b/services/shared/__init__.py
@@ -1,1 +1,3 @@
 from .security import SecurityHeadersMiddleware
+
+__all__ = ["SecurityHeadersMiddleware"]

--- a/services/shared/security.py
+++ b/services/shared/security.py
@@ -2,6 +2,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Inject basic security headers into each response."""
 

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -360,6 +360,7 @@ async def test_generate_report_concurrent(monkeypatch):
     duration = time.perf_counter() - start
     assert duration < sleep_dur * 1.5
 
+
 def test_insight_and_personas_invalid_field():
     r = client.post(
         "/insight-and-personas",


### PR DESCRIPTION
## Summary
- document how to run Playwright tests
- expose `SecurityHeadersMiddleware` in `__all__`
- ensure blank lines meet flake8 rules

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688a7d91b6b08329a1839e974b9732bf