### PR TITLE
Add Grafana alert for gateway 5xx

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,10 @@
+# Ops
+
+Operational scripts and infrastructure configuration.
+
+## Monitoring
+
+Grafana loads alert rules from `ops/grafana`. The file
+`gateway_5xx_alert.yaml` defines an alert that triggers when more than 5% of
+`unitron-gateway` responses are HTTP 5xx over a 10‑minute window. The rule
+notifies the team's Slack channel `#unitron-alerts`.

--- a/ops/grafana/gateway_5xx_alert.yaml
+++ b/ops/grafana/gateway_5xx_alert.yaml
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+groups:
+  - name: unitron-gateway
+    rules:
+      - alert: GatewayHigh5xx
+        expr: |
+          sum(rate(http_requests_total{service="unitron-gateway",status=~"5.."}[10m]))
+          /
+          sum(rate(http_requests_total{service="unitron-gateway"}[10m]))
+          > 0.05
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: unitron-gateway 5xx responses exceed 5% over 10m
+          description: More than 5% of unitron-gateway responses returned HTTP 5xx in the last 10 minutes.
+          slack_channel: "#unitron-alerts"


### PR DESCRIPTION
## Summary
- add Grafana rule to alert when gateway 5xx errors exceed 5% of requests
- document monitoring setup in ops README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a8f4ceacc8329ab4d99e9b0774e02