### PR TITLE
doc: note INSIGHT_TIMEOUT and testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and adjust values for local development
+OPENAI_API_KEY=your-openai-key
+INSIGHT_URL=http://localhost:8083
+INSIGHT_TIMEOUT=30
+MARTECH_URL=http://localhost:8081
+PROPERTY_URL=http://localhost:8082
+UI_ORIGIN=http://localhost:5173

--- a/interface/.env.example
+++ b/interface/.env.example
@@ -1,1 +1,3 @@
 VITE_API_BASE_URL=http://localhost:8080
+# Optional: override gateway wait time for insight calls (seconds)
+INSIGHT_TIMEOUT=30


### PR DESCRIPTION
## Summary
- document INSIGHT_TIMEOUT default of 30s in README and .env examples
- note shared httpx client, security headers, and degraded flag handling
- outline how to run unit and Playwright tests

## Testing
- `pytest`
- `npm test --prefix interface`
- `npx --yes playwright test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688a964459348329998ed061d596a752