### PR TITLE
Fix insight merging and empty evidence

### DIFF
--- a/interface/src/utils/insightParser.test.ts
+++ b/interface/src/utils/insightParser.test.ts
@@ -27,3 +27,10 @@ test('handles insights list with action field', () => {
     { id: '1', title: 'Do Y', reasoning: 'Why not', benefit: '' },
   ])
 })
+
+test('ignores insight object evidence when only actions present', () => {
+  const raw = { insight: { audience: 'X', insights: [{ action: 'A' }] } }
+  const parsed = parseInsightPayload(raw)
+  expect(parsed.actions.map((a) => a.title)).toEqual(['A'])
+  expect(parsed.evidence).toBe('')
+})

--- a/interface/src/utils/insightParser.ts
+++ b/interface/src/utils/insightParser.ts
@@ -50,9 +50,10 @@ export function parseInsightPayload(payload: unknown): ParsedInsight {
     data = { ...data, ...data.report }
   }
 
-  // flatten nested 'insight' field
+  // flatten nested 'insight' field and remove it to avoid misinterpreting it as evidence
   if (data && typeof data === 'object' && 'insight' in data && typeof data.insight === 'object') {
-    data = { ...data, ...data.insight }
+    const { insight, ...rest } = data as any
+    data = { ...rest, ...insight }
   }
 
   const evidenceRaw = getValue(data, ['evidence', 'summary', 'insight', 'report', 'text'])
@@ -60,8 +61,15 @@ export function parseInsightPayload(payload: unknown): ParsedInsight {
   if (typeof evidenceRaw === 'string') {
     evidence = evidenceRaw
   } else if (evidenceRaw && typeof evidenceRaw === 'object') {
-    const nested = getValue(evidenceRaw, ['evidence', 'summary', 'insight', 'report', 'text'])
+    const nested = getValue(evidenceRaw, [
+      'evidence',
+      'summary',
+      'insight',
+      'report',
+      'text',
+    ])
     if (typeof nested === 'string') evidence = nested
+    else if (nested === undefined) evidence = ''
     else evidence = JSON.stringify(evidenceRaw)
   } else if (evidenceRaw != null) {
     evidence = String(evidenceRaw)


### PR DESCRIPTION
## Summary
- remove `insight` object after flattening so it isn't used as evidence
- treat object evidence without nested keys as empty string
- test parsing of insight-only payload

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae240143083299f38e55ae5b2fcee