### PR TITLE
Add test for insight.insights parsing

### DIFF
--- a/interface/src/utils/insightParser.test.ts
+++ b/interface/src/utils/insightParser.test.ts
@@ -34,3 +34,20 @@ test('ignores insight object evidence when only actions present', () => {
   expect(parsed.actions.map((a) => a.title)).toEqual(['A'])
   expect(parsed.evidence).toBe('')
 })
+
+test('parses actions from insight.insights array', () => {
+  const raw = {
+    insight: {
+      insights: [
+        { action: 'Foo', reasoning: 'foo reason' },
+        { action: 'Bar', reasoning: 'bar reason' },
+      ],
+    },
+  }
+  const parsed = parseInsightPayload(raw)
+  expect(parsed.actions).toEqual([
+    { id: '0', title: 'Foo', reasoning: 'foo reason', benefit: '' },
+    { id: '1', title: 'Bar', reasoning: 'bar reason', benefit: '' },
+  ])
+  expect(parsed.evidence).toBe('')
+})


### PR DESCRIPTION
## Summary
- test nested `insight.insights` case in parser

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ae4d84c5483299a7d7443c5226f58