### PR TITLE
Remove obsolete postprocess-report call

### DIFF
--- a/interface/src/setupTests.ts
+++ b/interface/src/setupTests.ts
@@ -23,7 +23,6 @@ export const server = setupServer(
       result: { insight: { text: 'Flow' }, personas: { p1: { name: 'P1' } } },
     }),
   ),
-  http.post('/postprocess-report', () => Response.json({ downloads: {} })),
 )
 
 beforeAll(() => server.listen())

--- a/interface/src/utils/insightParser.test.ts
+++ b/interface/src/utils/insightParser.test.ts
@@ -13,3 +13,17 @@ test('converts action map to array', () => {
   expect(parsed.actions).toEqual([{ id: 'a1', title: 'T', reasoning: 'R', benefit: 'B' }])
   expect(parsed.degraded).toBe(true)
 })
+
+test('handles insights list with action field', () => {
+  const raw = {
+    insights: [
+      { action: 'Do X', reasoning: 'Because' },
+      { action: 'Do Y', reasoning: 'Why not' },
+    ],
+  }
+  const parsed = parseInsightPayload(raw)
+  expect(parsed.actions).toEqual([
+    { id: '0', title: 'Do X', reasoning: 'Because', benefit: '' },
+    { id: '1', title: 'Do Y', reasoning: 'Why not', benefit: '' },
+  ])
+})


### PR DESCRIPTION
## Summary
- drop `/postprocess-report` request in AnalyzerCard
- parse insight payload directly after `/generate-insight-and-personas`

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ac97329048329a6e324e777305572