### PR TITLE
Remove obsolete postprocess-report call

### DIFF
--- a/interface/src/components/InsightCard.test.tsx
+++ b/interface/src/components/InsightCard.test.tsx
@@ -59,5 +59,19 @@ test('handles non-array inputs gracefully', () => {
     degraded: false,
   }
   render(<InsightCard insight={insight as ParsedInsight} />)
-  screen.getAllByText('No data')
+  screen.getByText('No recommended actions were generated for this analysis.')
+  screen.getByText('No data')
+})
+
+test('shows fallback message when no actions', () => {
+  const insight: ParsedInsight = {
+    evidence: 'Proof',
+    personas: [{ id: 'p1', name: 'P1' }],
+    actions: [],
+    degraded: false,
+  }
+  render(<InsightCard insight={insight} />)
+  screen.getByText('Proof')
+  screen.getByText('P1')
+  screen.getByText('No recommended actions were generated for this analysis.')
 })

--- a/interface/src/components/InsightCard.tsx
+++ b/interface/src/components/InsightCard.tsx
@@ -107,7 +107,9 @@ export default function InsightCard({ insight, loading = false }: InsightCardPro
           </Accordion>
         </CardContent>
       ) : (
-        <CardContent>No data</CardContent>
+        <CardContent>
+          No recommended actions were generated for this analysis.
+        </CardContent>
       )}
       {hasPersonas ? (
         <CardContent>

--- a/interface/src/setupTests.ts
+++ b/interface/src/setupTests.ts
@@ -23,7 +23,6 @@ export const server = setupServer(
       result: { insight: { text: 'Flow' }, personas: { p1: { name: 'P1' } } },
     }),
   ),
-  http.post('/postprocess-report', () => Response.json({ downloads: {} })),
 )
 
 beforeAll(() => server.listen())

--- a/interface/src/utils/insightParser.test.ts
+++ b/interface/src/utils/insightParser.test.ts
@@ -13,3 +13,39 @@ test('converts action map to array', () => {
   expect(parsed.actions).toEqual([{ id: 'a1', title: 'T', reasoning: 'R', benefit: 'B' }])
   expect(parsed.degraded).toBe(true)
 })
+
+test('handles insights list with action field', () => {
+  const raw = {
+    insights: [
+      { action: 'Do X', reasoning: 'Because' },
+      { action: 'Do Y', reasoning: 'Why not' },
+    ],
+  }
+  const parsed = parseInsightPayload(raw)
+  expect(parsed.actions).toEqual([
+    { id: '0', title: 'Do X', reasoning: 'Because', benefit: '' },
+    { id: '1', title: 'Do Y', reasoning: 'Why not', benefit: '' },
+  ])
+})
+
+test('handles nested result.insight.insights', () => {
+  const raw = {
+    result: {
+      insight: {
+        evidence: 'E',
+        actions: [],
+        insights: [
+          { action: 'Foo', reasoning: 'Because' },
+          { action: 'Bar' },
+        ],
+        personas: [],
+      },
+    },
+  }
+  const parsed = parseInsightPayload(raw)
+  expect(parsed.evidence).toBe('E')
+  expect(parsed.actions).toEqual([
+    { id: '0', title: 'Foo', reasoning: 'Because', benefit: '' },
+    { id: '1', title: 'Bar', reasoning: '', benefit: '' },
+  ])
+})

--- a/interface/src/utils/insightParser.ts
+++ b/interface/src/utils/insightParser.ts
@@ -50,6 +50,11 @@ export function parseInsightPayload(payload: unknown): ParsedInsight {
     data = { ...data, ...data.report }
   }
 
+  // flatten nested 'result' field if present
+  if (data && typeof data === 'object' && 'result' in data && typeof (data as any).result === 'object') {
+    data = { ...data, ...(data as any).result }
+  }
+
   // flatten nested 'insight' field
   if (data && typeof data === 'object' && 'insight' in data && typeof data.insight === 'object') {
     data = { ...data, ...data.insight }
@@ -87,15 +92,31 @@ export function parseInsightPayload(payload: unknown): ParsedInsight {
   }
 
   let actions: Action[] = []
-  const actionRaw = getValue(data, ['actions', 'action_items', 'next_best_actions']) || []
+  let actionRaw =
+    getValue(data, ['actions', 'action_items', 'next_best_actions']) || []
+  if (
+    (!actionRaw ||
+      (Array.isArray(actionRaw) && actionRaw.length === 0)) &&
+    Array.isArray((data as any).insights)
+  ) {
+    actionRaw = (data as any).insights
+  }
   if (Array.isArray(actionRaw)) {
     actions = actionRaw.map((a, i) => {
       if (typeof a === 'string') {
         return { id: String(i), title: a, reasoning: '', benefit: '' }
       }
       if (a && typeof a === 'object') {
-        const { id = String(i), title = '', reasoning = '', benefit = '', ...rest } = a as any
-        return { id: String(id), title, reasoning, benefit, ...rest }
+        const {
+          id = String(i),
+          title = '',
+          reasoning = '',
+          benefit = '',
+          action,
+          ...rest
+        } = a as any
+        const titleVal = title || action || ''
+        return { id: String(id), title: titleVal, reasoning, benefit, ...rest }
       }
       return { id: String(i), title: String(a), reasoning: '', benefit: '' }
     })
@@ -105,8 +126,9 @@ export function parseInsightPayload(payload: unknown): ParsedInsight {
         return { id: k, title: v, reasoning: '', benefit: '' }
       }
       if (v && typeof v === 'object') {
-        const { title = '', reasoning = '', benefit = '', ...rest } = v as any
-        return { id: k, title, reasoning, benefit, ...rest }
+        const { title = '', reasoning = '', benefit = '', action, ...rest } = v as any
+        const titleVal = title || action || ''
+        return { id: k, title: titleVal, reasoning, benefit, ...rest }
       }
       return { id: k, title: String(v), reasoning: '', benefit: '' }
     })


### PR DESCRIPTION
## Summary
- drop `/postprocess-report` request in AnalyzerCard
- parse insight payload directly after `/generate-insight-and-personas`
- show message when no actions are returned
- parse nested `result.insight.insights` payloads

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ac97329048329a6e324e777305572