### PR TITLE
Add OPENAI_MODEL support

### DIFF
--- a/services/insight/README.md
+++ b/services/insight/README.md
@@ -18,7 +18,8 @@ It runs at `http://localhost:8083` when using Docker Compose.
 ## Environment variables
 
 - `OPENAI_API_KEY` – required key for the OpenAI client.
-- `OPENAI_MODEL` – chat model name (default `gpt-4`).
+- `OPENAI_MODEL` – chat model name used by `call_openai_with_retry`
+  (default `gpt-4`).
 - `MACRO_SECTION_CAP` – maximum number of macro sections returned by `/research`.
 
 ### Normalized insight schema

--- a/services/insight/orchestrator.py
+++ b/services/insight/orchestrator.py
@@ -44,7 +44,7 @@ async def call_openai_with_retry(
     messages: list[dict[str, str]],
     *,
     max_tokens: int | None = None,
-    model: str = "gpt-4",
+    model: str | None = None,
 ) -> tuple[str, bool]:
     """Call OpenAI with retry and return ``(content, degraded)``."""
 
@@ -55,12 +55,14 @@ async def call_openai_with_retry(
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY missing")
 
+    selected_model = model or os.getenv("OPENAI_MODEL", "gpt-4")
+
     client = openai.AsyncOpenAI(api_key=api_key)
     delays = [1, 2, 4]
     for attempt in range(3):
         try:
             resp = await client.chat.completions.create(
-                model=model,
+                model=selected_model,
                 messages=messages,
                 **({"max_tokens": max_tokens} if max_tokens is not None else {}),
             )

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -42,6 +42,7 @@ def test_generate_insights(monkeypatch):
     monkeypatch.setattr(insight_mod, "openai", dummy_module, raising=False)
     monkeypatch.setattr(insight_mod.orchestrator, "openai", dummy_module, raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4")
 
     r = client.post("/generate-insights", json={"text": "  some text\n"})
     assert r.status_code == 200
@@ -100,6 +101,7 @@ def test_research_trim(monkeypatch):
     monkeypatch.setattr(insight_mod, "openai", dummy_module, raising=False)
     monkeypatch.setattr(insight_mod.orchestrator, "openai", dummy_module, raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4")
 
     r = client.post("/research", json={"topic": "AI"})
     assert r.status_code == 200
@@ -374,6 +376,7 @@ async def test_generate_report_concurrent(monkeypatch):
         raising=False,
     )
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4")
 
     start = time.perf_counter()
     await asyncio.gather(
@@ -412,6 +415,7 @@ async def test_generate_report_json_error(monkeypatch):
     dummy_module = types.SimpleNamespace(AsyncOpenAI=lambda api_key=None: DummyClient())
     monkeypatch.setattr(insight_mod.orchestrator, "openai", dummy_module, raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4")
 
     result = await insight_mod.orchestrator.generate_report("prompt")
     assert result == {"insight": "not json", "degraded": True}

--- a/tests/test_insight_retry.py
+++ b/tests/test_insight_retry.py
@@ -41,6 +41,7 @@ def test_retry_rate_limit(monkeypatch):
     monkeypatch.setattr(insight_mod, "openai", dummy_module, raising=False)
     monkeypatch.setattr(insight_mod.orchestrator, "openai", dummy_module, raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4")
 
     r = client.post("/generate-insights", json={"text": "hi"})
     assert r.status_code == 200


### PR DESCRIPTION
## Summary
- read `OPENAI_MODEL` inside `call_openai_with_retry`
- document new setting
- set `OPENAI_MODEL` in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba5b1e3d483299a862c122abe0d32