### PR TITLE
Respect UI_ORIGIN for CORS

### DIFF
--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -31,12 +31,13 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-# Allow calls from the UI hosted on a different origin during development
-# UI_ORIGIN should contain the frontend domain
-# (e.g. http://localhost:5173)
+# Allow calls from the UI hosted on a different origin during development.
+# UI_ORIGIN should contain the frontend domain (e.g. http://localhost:5173)
+ui_origin = os.getenv("UI_ORIGIN")
+allow = [ui_origin] if ui_origin else ["*"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow,
     allow_methods=["*"],
     allow_headers=["Content-Type", "Authorization"],
 )

--- a/services/insight/app.py
+++ b/services/insight/app.py
@@ -42,9 +42,11 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+ui_origin = os.getenv("UI_ORIGIN")
+allow = [ui_origin] if ui_origin else ["*"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow,
     allow_methods=["*"],
     allow_headers=["Content-Type", "Authorization"],
 )

--- a/services/martech/app.py
+++ b/services/martech/app.py
@@ -56,12 +56,13 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-# Allow calls from the UI hosted on a different origin during development
-# UI_ORIGIN should contain the frontend domain
-# (e.g. http://localhost:5173)
+# Allow calls from the UI hosted on a different origin during development.
+# UI_ORIGIN should contain the frontend domain (e.g. http://localhost:5173)
+ui_origin = os.getenv("UI_ORIGIN")
+allow = [ui_origin] if ui_origin else ["*"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow,
     allow_methods=["*"],
     allow_headers=["Content-Type", "Authorization"],
 )

--- a/services/property/app.py
+++ b/services/property/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from urllib.parse import urlparse
 import socket
+import os
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException
 import httpx
@@ -23,12 +24,13 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-# Allow web interface to call this API from another origin during development
-# UI_ORIGIN should contain the frontend domain
-# (e.g. http://localhost:5173)
+# Allow web interface to call this API from another origin during development.
+# UI_ORIGIN should contain the frontend domain (e.g. http://localhost:5173)
+ui_origin = os.getenv("UI_ORIGIN")
+allow = [ui_origin] if ui_origin else ["*"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow,
     allow_methods=["*"],
     allow_headers=["Content-Type", "Authorization"],
 )

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -22,6 +22,24 @@ def test_ready():
     assert r.json() == {"ready": True}
 
 
+def test_options_respects_ui_origin(monkeypatch):
+    monkeypatch.setenv("UI_ORIGIN", "http://ui.example")
+    import importlib
+    import services.insight.app as ins
+
+    ins = importlib.reload(ins)
+    local_client = TestClient(ins.app)
+    r = local_client.options(
+        "/generate-insights",
+        headers={
+            "Origin": "http://ui.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers["access-control-allow-origin"] == "http://ui.example"
+
+
 def test_generate_insights(monkeypatch):
     class DummyResp:
         def __init__(self, content: str) -> None:

--- a/tests/test_martech.py
+++ b/tests/test_martech.py
@@ -121,6 +121,24 @@ def test_options_analyze():
     assert r.headers['x-content-type-options'] == 'nosniff'
 
 
+def test_options_respects_ui_origin(monkeypatch):
+    monkeypatch.setenv("UI_ORIGIN", "http://ui.example")
+    import importlib
+    import services.martech.app as mt
+
+    mt = importlib.reload(mt)
+    local_client = TestClient(mt.app)
+    r = local_client.options(
+        '/analyze',
+        headers={
+            'Origin': 'http://ui.example',
+            'Access-Control-Request-Method': 'POST',
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers['access-control-allow-origin'] == 'http://ui.example'
+
+
 def test_analyze_handles_request_error(monkeypatch):
     client.get('/ready')
 

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -50,3 +50,21 @@ def test_options_analyze():
     assert "Authorization" in allowed
     assert r.headers["x-frame-options"] == "DENY"
     assert r.headers["x-content-type-options"] == "nosniff"
+
+
+def test_options_respects_ui_origin(monkeypatch):
+    monkeypatch.setenv("UI_ORIGIN", "http://ui.example")
+    import importlib
+    import services.property.app as prop
+
+    prop = importlib.reload(prop)
+    local_client = TestClient(prop.app)
+    r = local_client.options(
+        "/analyze",
+        headers={
+            "Origin": "http://ui.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers["access-control-allow-origin"] == "http://ui.example"


### PR DESCRIPTION
## Summary
- read `UI_ORIGIN` to configure CORS middleware for each API service
- test that the middleware uses the env variable

## Testing
- `pytest -q --color=no`

------
https://chatgpt.com/codex/tasks/task_e_688bae7e61288329bfca9a2a45821282