### PR TITLE
Simplify insight parser

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -41,10 +41,8 @@ Make sure `OPENAI_API_KEY` is set in that service's environment so it can reach 
 
 The analysis result now includes an "Executive Summary" showing a short
 insight fetched from the gateway. When a user clicks **Generate
-Insights** the frontend calls `/generate-insight-and-personas`. The
-response may vary, so `parseInsightPayload` in `src/utils` normalizes
-the data. It also supports payloads shaped as `{ insights: [{ action: ... }] }`
-or the same list nested under `insight`. Objects that lack a summary are
-still displayed using only their actions. The parsed result is then passed
-to `InsightCard` which renders the summary, recommended actions and any
-personas.
+Insights** the frontend calls `/generate-insight-and-personas`.
+`parseInsightPayload` in `src/utils` maps the canonical response fields
+so components consume a consistent structure. The parsed result is then
+passed to `InsightCard` which renders the summary, recommended actions
+and any personas.

--- a/interface/src/utils/insightParser.test.ts
+++ b/interface/src/utils/insightParser.test.ts
@@ -14,78 +14,18 @@ test('converts action map to array', () => {
   expect(parsed.degraded).toBe(true)
 })
 
-test('handles insights list with action field', () => {
+test('parses canonical fields', () => {
   const raw = {
-    insights: [
-      { action: 'Do X', reasoning: 'Because' },
-      { action: 'Do Y', reasoning: 'Why not' },
-    ],
+    insight: { actions: [{ title: 'T', reasoning: 'R', benefit: 'B' }], evidence: 'E' },
+    personas: [{ id: 'p1', name: 'P1' }],
+    degraded: false,
   }
   const parsed = parseInsightPayload(raw)
-  expect(parsed.actions).toEqual([
-    { id: '1', title: 'Do X', reasoning: 'Because', benefit: '' },
-    { id: '2', title: 'Do Y', reasoning: 'Why not', benefit: '' },
-  ])
-})
-
-
-test('handles nested result.insight.insights', () => {
-  const raw = {
-    result: {
-      insight: {
-        evidence: 'E',
-        actions: [],
-        insights: [
-          { action: 'Foo', reasoning: 'Because' },
-          { action: 'Bar' },
-        ],
-        personas: [],
-      },
-    },
-  }
-  const parsed = parseInsightPayload(raw)
-  expect(parsed.evidence).toBe('E')
-  expect(parsed.actions).toEqual([
-    { id: '1', title: 'Foo', reasoning: 'Because', benefit: '' },
-    { id: '2', title: 'Bar', reasoning: '', benefit: '' },
-  ])
-})
-
-test('maps name and description fields', () => {
-  const raw = {
-    result: {
-      insight: {
-        insights: [
-          { name: 'X', description: 'why' },
-          { name: 'Y' },
-        ],
-      },
-    },
-  }
-  const parsed = parseInsightPayload(raw)
-  expect(parsed.actions).toEqual([
-    { id: '1', title: 'X', reasoning: 'why', benefit: '' },
-    { id: '2', title: 'Y', reasoning: '', benefit: '' },
-  ])
-})
-
-test('handles evidence.insights list', () => {
-  const raw = {
-    insight: {
-      actions: [],
-      evidence: {
-        insights: [
-          { title: 'Improve', description: 'why' },
-          { title: 'Scale' },
-        ],
-      },
-      personas: [],
-    },
-  }
-  const parsed = parseInsightPayload(raw)
-  expect(parsed.actions).toEqual([
-    { id: '1', title: 'Improve', reasoning: 'why', benefit: '' },
-    { id: '2', title: 'Scale', reasoning: '', benefit: '' },
-  ])
+  expect(parsed).toEqual({
+    actions: [{ id: '1', title: 'T', reasoning: 'R', benefit: 'B' }],
+    evidence: 'E',
+    personas: [{ id: 'p1', name: 'P1' }],
+    degraded: false,
+  })
 })
 

--- a/interface/src/utils/insightParser.ts
+++ b/interface/src/utils/insightParser.ts
@@ -22,15 +22,6 @@ export interface ParsedInsight {
   degraded: boolean
 }
 
-function getValue(obj: any, keys: string[]): any {
-  for (const k of keys) {
-    if (obj && typeof obj === 'object' && k in obj) {
-      return (obj as any)[k]
-    }
-  }
-  return undefined
-}
-
 /**
  * Parse various insight payload shapes returned by the backend.
  * Strings are interpreted as JSON when possible.
@@ -41,48 +32,25 @@ export function parseInsightPayload(payload: unknown): ParsedInsight {
     try {
       data = JSON.parse(payload)
     } catch {
-      data = { evidence: payload }
+      data = { insight: { evidence: payload } }
     }
   }
 
-  // drill into nested 'report' field if present
-  if (data && typeof data === 'object' && 'report' in data && typeof data.report === 'object') {
-    data = { ...data, ...data.report }
-  }
-
-
-  // flatten nested 'result' field if present
   if (data && typeof data === 'object' && 'result' in data && typeof (data as any).result === 'object') {
-    data = { ...data, ...(data as any).result }
+    data = (data as any).result
   }
 
-  // flatten nested 'insight' field
-  if (data && typeof data === 'object' && 'insight' in data && typeof data.insight === 'object') {
-    const { insight, ...rest } = data as any
-    data = { ...rest, ...insight }
-  }
+  const insight = (data as any)?.insight ?? {}
 
-  const evidenceRaw = getValue(data, ['evidence', 'summary', 'insight', 'report', 'text'])
+  const actionRaw = insight.actions ?? []
+  const evidenceRaw = insight.evidence ?? ''
+  const personaRaw = (data as any)?.personas ?? []
+
   let evidence = ''
-  if (typeof evidenceRaw === 'string') {
-    evidence = evidenceRaw
-  } else if (evidenceRaw && typeof evidenceRaw === 'object') {
-    const nested = getValue(evidenceRaw, [
-      'evidence',
-      'summary',
-      'insight',
-      'report',
-      'text',
-    ])
-    if (typeof nested === 'string') evidence = nested
-    else if (nested === undefined) evidence = ''
-    else evidence = JSON.stringify(evidenceRaw)
-  } else if (evidenceRaw != null) {
-    evidence = String(evidenceRaw)
-  }
+  if (typeof evidenceRaw === 'string') evidence = evidenceRaw
+  else if (evidenceRaw != null) evidence = JSON.stringify(evidenceRaw)
 
   let personas: Persona[] = []
-  const personaRaw = getValue(data, ['personas', 'generated_buyer_personas', 'buyer_personas']) || []
   if (Array.isArray(personaRaw)) {
     personas = personaRaw.map((p, i) => {
       if (typeof p === 'string') return { id: String(i), name: p }
@@ -101,100 +69,33 @@ export function parseInsightPayload(payload: unknown): ParsedInsight {
   }
 
   let actions: Action[] = []
-  const nested =
-    data &&
-    typeof data === 'object' &&
-    (data as any).result &&
-    typeof (data as any).result === 'object' &&
-    (data as any).result.insight &&
-    typeof (data as any).result.insight === 'object' &&
-    Array.isArray((data as any).result.insight.insights)
-      ? (data as any).result.insight.insights
-      : undefined
-
-  let actionRaw =
-    getValue(data, ['actions', 'action_items', 'next_best_actions']) || []
-
-  if (
-    (!actionRaw ||
-      (Array.isArray(actionRaw) && actionRaw.length === 0)) &&
-    Array.isArray((data as any).insights)
-  ) {
-    actionRaw = (data as any).insights
-  }
-
-  if (
-    (!actionRaw ||
-      (Array.isArray(actionRaw) && actionRaw.length === 0)) &&
-    Array.isArray(nested)
-  ) {
-    actionRaw = nested
-  }
-
-  if (
-    (!actionRaw ||
-      (Array.isArray(actionRaw) && actionRaw.length === 0)) &&
-    data &&
-    typeof data === 'object' &&
-    (data as any).evidence &&
-    typeof (data as any).evidence === 'object' &&
-    Array.isArray((data as any).evidence.insights)
-  ) {
-    actionRaw = (data as any).evidence.insights
-  }
-
   if (Array.isArray(actionRaw)) {
     actions = actionRaw.map((item, idx) => {
       if (typeof item === 'string') {
         return { id: String(idx + 1), title: item, reasoning: '', benefit: '' }
       }
       if (item && typeof item === 'object') {
-        const {
-          name,
-          description,
-          title = '',
-          reasoning = '',
-          benefit = '',
-          action,
-          ...rest
-        } = item as any
-        const titleVal = name || title || action || 'Action'
-        const reasonVal = description || reasoning || ''
-        return {
-          id: String(idx + 1),
-          title: titleVal,
-          reasoning: reasonVal,
-          benefit,
-          ...rest,
-        }
+        const { id = String(idx + 1), title, name, reasoning, description, benefit = '', action, ...rest } = item as any
+        const titleVal = title ?? name ?? action ?? 'Action'
+        const reasonVal = reasoning ?? description ?? ''
+        return { id: String(id), title: titleVal, reasoning: reasonVal, benefit, ...rest }
       }
       return { id: String(idx + 1), title: String(item), reasoning: '', benefit: '' }
     })
   } else if (actionRaw && typeof actionRaw === 'object') {
     actions = Object.entries(actionRaw).map(([k, v]) => {
-      if (typeof v === 'string') {
-        return { id: k, title: v, reasoning: '', benefit: '' }
-      }
+      if (typeof v === 'string') return { id: k, title: v, reasoning: '', benefit: '' }
       if (v && typeof v === 'object') {
-        const {
-          name,
-          description,
-          title = '',
-          reasoning = '',
-          benefit = '',
-          action,
-          ...rest
-        } = v as any
-        const titleVal = name || title || action || 'Action'
-        const reasonVal = description || reasoning || ''
+        const { title, name, reasoning, description, benefit = '', action, ...rest } = v as any
+        const titleVal = title ?? name ?? action ?? 'Action'
+        const reasonVal = reasoning ?? description ?? ''
         return { id: k, title: titleVal, reasoning: reasonVal, benefit, ...rest }
       }
       return { id: k, title: String(v), reasoning: '', benefit: '' }
     })
   }
 
-  const degradedRaw = getValue(data, ['degraded'])
-  const degraded = Boolean(degradedRaw)
+  const degraded = Boolean((data as any)?.degraded)
 
   return { actions, evidence, personas, degraded }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     beautifulsoup4
     python-wappalyzer
     setuptools
+    playwright
     pytest-asyncio
 commands = pytest
 


### PR DESCRIPTION
## Summary
- refactor `parseInsightPayload` to expect canonical fields
- update tests for the streamlined shape
- note canonical mapping in README
- install Playwright in tox environment

## Testing
- `npx vitest run --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bc038edfc8329891f564fa67f4de8