### PR TITLE
Handle JSON code fences

### DIFF
--- a/services/insight/orchestrator.py
+++ b/services/insight/orchestrator.py
@@ -117,6 +117,17 @@ def build_prompt(
     return prompt
 
 
+def _extract_json_block(text: str) -> str:
+    """Return ``text`` minus surrounding ```json fences, if present."""
+
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if len(lines) >= 3 and lines[0].startswith("```") and lines[-1].startswith("```"):
+            return "\n".join(lines[1:-1]).strip()
+    return stripped
+
+
 async def generate_report(
     prompt: str, *, timeout: int = 30, retries: int = 2
 ) -> dict[str, Any]:
@@ -144,6 +155,6 @@ async def generate_report(
     if degraded:
         return {"error": "[Data Gap]"}
     try:
-        return json.loads(content)
+        return json.loads(_extract_json_block(content))
     except JSONDecodeError:
         return {"insight": content, "degraded": True}

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -417,7 +417,8 @@ def test_insight_and_personas_invalid_field():
 async def test_generate_report_json_error(monkeypatch):
     class DummyResp:
         def __init__(self) -> None:
-            message_obj = type("obj", (), {"content": "not json"})()
+            json_snippet = "```json\n{\"foo\": \"bar\"}\n```"
+            message_obj = type("obj", (), {"content": json_snippet})()
             self.choices = [type("obj", (), {"message": message_obj})()]
 
     async def fake_create(**_kwargs):
@@ -436,4 +437,4 @@ async def test_generate_report_json_error(monkeypatch):
     monkeypatch.setenv("OPENAI_MODEL", "gpt-4")
 
     result = await insight_mod.orchestrator.generate_report("prompt")
-    assert result == {"insight": "not json", "degraded": True}
+    assert result == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- detect JSON fenced blocks returned by the LLM
- parse responses after stripping ```json fences
- test parsing of fenced JSON snippets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bdb607f4c83299cbe0f8f2c04d39a