### PR TITLE
Add OPENAI_MAX_TOKENS support

### DIFF
--- a/services/insight/README.md
+++ b/services/insight/README.md
@@ -20,6 +20,8 @@ It runs at `http://localhost:8083` when using Docker Compose.
 - `OPENAI_API_KEY` – required key for the OpenAI client.
 - `OPENAI_MODEL` – chat model name used by `call_openai_with_retry`
   (default `gpt-4`).
+- `OPENAI_MAX_TOKENS` – maximum tokens returned by the LLM
+  (default `800`).
 - `MACRO_SECTION_CAP` – maximum number of macro sections returned by `/research`.
 
 ### Normalized insight schema

--- a/services/insight/orchestrator.py
+++ b/services/insight/orchestrator.py
@@ -14,6 +14,9 @@ except Exception:  # noqa: BLE001
 
 logger = logging.getLogger(__name__)
 
+# Default token limit for OpenAI responses
+OPENAI_MAX_TOKENS = int(os.getenv("OPENAI_MAX_TOKENS", "800"))
+
 # Canonical schema used when prompting the LLM. The example combines a
 # TypeScript interface and JSON snippet so tests can verify the keys
 # are present in the service response.
@@ -145,7 +148,7 @@ async def generate_report(
     ]
     try:
         content, degraded = await asyncio.wait_for(
-            call_openai_with_retry(messages),
+            call_openai_with_retry(messages, max_tokens=OPENAI_MAX_TOKENS),
             timeout=timeout,
         )
     except Exception:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- allow configuring OpenAI token limit via `OPENAI_MAX_TOKENS`
- pass max token limit to `call_openai_with_retry`
- document `OPENAI_MAX_TOKENS` in Insight service README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688bde8368248329a5c78d33949f584b