### PR TITLE
Add fenced json handling

### DIFF
--- a/services/insight/orchestrator.py
+++ b/services/insight/orchestrator.py
@@ -127,7 +127,10 @@ def _extract_json_block(text: str) -> str:
     if stripped.startswith("```"):
         lines = stripped.splitlines()
         if len(lines) >= 3 and lines[0].startswith("```") and lines[-1].startswith("```"):
-            return "\n".join(lines[1:-1]).strip()
+            inner = "\n".join(lines[1:-1]).strip()
+            if inner.lower().startswith("json\n"):
+                inner = inner.split("\n", 1)[1].strip()
+            return inner
     return stripped
 
 


### PR DESCRIPTION
## Summary
- handle nested `json` label inside fenced code blocks
- test that `generate_report` parses fenced JSON outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688be86b2d1c8329beceafbbd80902b3