### PR TITLE
Add persona example and unknown placeholders

### DIFF
--- a/services/insight/README.md
+++ b/services/insight/README.md
@@ -12,7 +12,7 @@ It runs at `http://localhost:8083` when using Docker Compose.
 - `POST /postprocess-report` – body `{ "report": {...} }` returns the same report
   plus base64-encoded downloads.
 - `POST /insight-and-personas` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress", "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS" }`
-  returns { "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false }. Insight and persona prompts run concurrently. If the persona response is empty, two placeholder personas are created from the company URL and technology fields. The gateway will return a timeout after 20s if the insight service is slow. The optional fields fine‑tune how the report is generated.
+  returns { "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false }. Insight and persona prompts run concurrently. The `evidence` field summarizing findings is always included. If the persona response is empty, placeholder company and technology personas are created with all attributes set to "unknown". The gateway will return a timeout after 20s if the insight service is slow. The optional fields fine‑tune how the report is generated.
 - `GET /metrics` – usage counters for requests and data gaps.
 
 ## Environment variables
@@ -27,7 +27,9 @@ It runs at `http://localhost:8083` when using Docker Compose.
 ### Normalized insight schema
 
 The insight service replies with an object containing an `insight` field. This
-field follows a consistent shape regardless of prompt details:
+field follows a consistent shape regardless of prompt details. An `evidence`
+summary is always included, and placeholder personas with `"unknown"` fields
+are returned when persona data is missing:
 
 ```json
 {
@@ -36,7 +38,7 @@ field follows a consistent shape regardless of prompt details:
     {"id": "1", "title": "Action", "reasoning": "why", "benefit": "result"}
   ],
   "personas": [
-    {"id": "P1", "name": "Buyer"}
+    {"id": "P1", "name": "Buyer", "role": "unknown", "goal": "unknown", "challenge": "unknown"}
   ],
   "degraded": false
 }
@@ -74,7 +76,7 @@ Expected response snippet:
 ```json
 {
   "insight": { "actions": [], "evidence": "..." },
-  "personas": [{"id": "P1"}],
+  "personas": [{"id": "P1", "name": "Buyer", "role": "unknown", "goal": "unknown", "challenge": "unknown"}],
   "cms_manual": "WordPress",
   "degraded": false
 }

--- a/services/insight/app.py
+++ b/services/insight/app.py
@@ -427,8 +427,20 @@ async def insight_and_personas(req: InsightPersonaRequest) -> JSONResponse:
                     tech_names.extend(vals)
             tech_text = ", ".join(sorted(set(tech_names))) or "unknown"
             personas_list = [
-                {"id": "company", "name": domain},
-                {"id": "tech", "name": tech_text},
+                {
+                    "id": "company",
+                    "name": domain,
+                    "role": "unknown",
+                    "goal": "unknown",
+                    "challenge": "unknown",
+                },
+                {
+                    "id": "tech",
+                    "name": tech_text,
+                    "role": "unknown",
+                    "goal": "unknown",
+                    "challenge": "unknown",
+                },
             ]
 
         actions: list[Any] = []

--- a/services/insight/orchestrator.py
+++ b/services/insight/orchestrator.py
@@ -42,6 +42,30 @@ interface NextBestAction {
 ```
 """
 
+# Example persona schema with all fields populated. Unknown attributes use
+# the literal string "unknown" to ensure every key has a value.
+PERSONA_EXAMPLE = """
+```ts
+interface Persona {
+  id: string;
+  name: string;
+  role: string;
+  goal: string;
+  challenge: string;
+}
+```
+
+```json
+{
+  "id": "P1",
+  "name": "Jane Doe",
+  "role": "CTO",
+  "goal": "Improve developer productivity",
+  "challenge": "unknown"
+}
+```
+"""
+
 
 async def call_openai_with_retry(
     messages: list[dict[str, str]],
@@ -112,9 +136,10 @@ def build_prompt(
         f"Company: {company_text}\n"
         f"Technology: {tech_text}\n"
         f"Question: {question}\n"
-        "Respond only with a JSON payload."
+        "Respond only with a JSON payload. Always include an evidence field summarizing the findings in 1-2 sentences. Provide company, technology and user personas. Fill every persona attribute; use the literal string \"unknown\" when data is not available."
     )
     prompt += "\n" + NEXT_BEST_ACTION_EXAMPLE
+    prompt += "\n" + PERSONA_EXAMPLE
     prompt += ("\nReply only with JSON matching the above structure inside a"
                " ```json code block. Keep empty arrays/objects.")
     return prompt

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -354,8 +354,20 @@ def test_insight_and_personas_warnings(monkeypatch):
     result = r.json()
     assert result["insight"] == {"actions": [], "evidence": {"data": huge}}
     assert result["personas"] == [
-        {"id": "company", "name": "e"},
-        {"id": "tech", "name": "unknown"},
+        {
+            "id": "company",
+            "name": "e",
+            "role": "unknown",
+            "goal": "unknown",
+            "challenge": "unknown",
+        },
+        {
+            "id": "tech",
+            "name": "unknown",
+            "role": "unknown",
+            "goal": "unknown",
+            "challenge": "unknown",
+        },
     ]
     assert "cms_manual" not in result
     assert result["degraded"] is True
@@ -385,8 +397,20 @@ def test_insight_and_personas_empty_personas(monkeypatch):
     assert r.status_code == 200
     result = r.json()
     assert result["personas"] == [
-        {"id": "company", "name": "ex"},
-        {"id": "tech", "name": "React, WP"},
+        {
+            "id": "company",
+            "name": "ex",
+            "role": "unknown",
+            "goal": "unknown",
+            "challenge": "unknown",
+        },
+        {
+            "id": "tech",
+            "name": "React, WP",
+            "role": "unknown",
+            "goal": "unknown",
+            "challenge": "unknown",
+        },
     ]
 
 


### PR DESCRIPTION
## Summary
- add PERSONA_EXAMPLE schema and expand prompt requirements to always return evidence and personas with filled attributes
- document new behavior and add placeholder personas with "unknown" fields when data missing
- test fallback personas to ensure unknown attributes are present

## Testing
- `pytest tests/test_insight.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688c09e42e648329beba78c37f1bbb4a