### PR TITLE
feat: handle missing persona fields in InsightCard

### DIFF
--- a/interface/src/components/InsightCard.suite.test.tsx
+++ b/interface/src/components/InsightCard.suite.test.tsx
@@ -50,4 +50,19 @@ describe('InsightCard', () => {
     await userEvent.click(screen.getByText('Copy Actions'))
     expect(write).toHaveBeenCalled()
   })
+
+  test('renders Not provided for missing persona fields', () => {
+    const insight: ParsedInsight = {
+      evidence: '',
+      personas: [
+        { id: 'p1', name: 'P1', demographics: '', company: null },
+      ],
+      actions: [],
+      degraded: false,
+    }
+    render(<InsightCard insight={insight} />)
+    screen.getByText(/demographics/i)
+    screen.getByText(/company/i)
+    expect(screen.getAllByText('Not provided')).toHaveLength(2)
+  })
 })

--- a/interface/src/components/InsightCard.test.tsx
+++ b/interface/src/components/InsightCard.test.tsx
@@ -24,6 +24,21 @@ test('renders evidence, actions and personas', () => {
   screen.getByText('buyer')
 })
 
+test('renders Not provided for missing persona fields', () => {
+  const insight: ParsedInsight = {
+    evidence: '',
+    personas: [
+      { id: 'p1', name: 'P1', demographics: '', company: null },
+    ],
+    actions: [],
+    degraded: false,
+  }
+  render(<InsightCard insight={insight} />)
+  screen.getByText(/demographics/i)
+  screen.getByText(/company/i)
+  expect(screen.getAllByText('Not provided')).toHaveLength(2)
+})
+
 test('copies markdown to clipboard and opens sheet', async () => {
   const write = vi.fn()
   Object.assign(navigator as any, { clipboard: { writeText: write } })

--- a/interface/src/components/InsightCard.tsx
+++ b/interface/src/components/InsightCard.tsx
@@ -28,6 +28,10 @@ function actionsToMarkdown(actions: Action[]): string {
     .join('\n\n')
 }
 
+function renderValue(v: unknown): string {
+  return v === undefined || v === null || v === '' ? 'Not provided' : String(v)
+}
+
 export interface InsightCardProps {
   insight: ParsedInsight
   loading?: boolean
@@ -130,7 +134,7 @@ export default function InsightCard({ insight, loading = false }: InsightCardPro
                     .map(([k, v]) => (
                       <div key={k} className="text-sm text-gray-600">
                         <span className="font-medium capitalize">{k}:</span>{' '}
-                        {String(v)}
+                        {renderValue(v)}
                       </div>
                     ))}
                 </div>


### PR DESCRIPTION
## Summary
- show `Not provided` when persona details are empty
- test InsightCard placeholder rendering

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c14f810a0832995770290b974c327