### PR TITLE
Default missing persona fields to unknown

### DIFF
--- a/interface/src/utils/insightParser.test.ts
+++ b/interface/src/utils/insightParser.test.ts
@@ -4,7 +4,17 @@ import { parseInsightPayload } from './insightParser'
 test('converts persona map to array', () => {
   const raw = { insight: { actions: [], evidence: '' }, personas: { p1: { name: 'P1' } }, degraded: false }
   const parsed = parseInsightPayload(raw)
-  expect(parsed.personas).toEqual([{ id: 'p1', name: 'P1' }])
+  expect(parsed.personas).toEqual([
+    { id: 'p1', name: 'P1', demographics: 'unknown', needs: 'unknown', goals: 'unknown' },
+  ])
+})
+
+test('defaults missing persona fields to unknown', () => {
+  const raw = { insight: { actions: [], evidence: '' }, personas: [{ id: 'p1', name: 'P1' }], degraded: false }
+  const parsed = parseInsightPayload(raw)
+  expect(parsed.personas).toEqual([
+    { id: 'p1', name: 'P1', demographics: 'unknown', needs: 'unknown', goals: 'unknown' },
+  ])
 })
 
 test('converts action map to array', () => {
@@ -24,7 +34,9 @@ test('parses canonical fields', () => {
   expect(parsed).toEqual({
     actions: [{ id: '1', title: 'T', reasoning: 'R', benefit: 'B' }],
     evidence: 'E',
-    personas: [{ id: 'p1', name: 'P1' }],
+    personas: [
+      { id: 'p1', name: 'P1', demographics: 'unknown', needs: 'unknown', goals: 'unknown' },
+    ],
     degraded: false,
   })
 })

--- a/interface/src/utils/insightParser.ts
+++ b/interface/src/utils/insightParser.ts
@@ -53,18 +53,48 @@ export function parseInsightPayload(payload: unknown): ParsedInsight {
   let personas: Persona[] = []
   if (Array.isArray(personaRaw)) {
     personas = personaRaw.map((p, i) => {
-      if (typeof p === 'string') return { id: String(i), name: p }
+      if (typeof p === 'string')
+        return { id: String(i), name: p, demographics: 'unknown', needs: 'unknown', goals: 'unknown' }
       if (p && typeof p === 'object') {
-        const { id = String(i), name = '', demographics, needs, goals, ...rest } = p as any
+        const {
+          id = String(i),
+          name = '',
+          demographics = 'unknown',
+          needs = 'unknown',
+          goals = 'unknown',
+          ...rest
+        } = p as any
         return { id: String(id), name, demographics, needs, goals, ...rest }
       }
-      return { id: String(i), name: String(p) }
+      return {
+        id: String(i),
+        name: String(p),
+        demographics: 'unknown',
+        needs: 'unknown',
+        goals: 'unknown',
+      }
     })
   } else if (personaRaw && typeof personaRaw === 'object') {
     personas = Object.entries(personaRaw).map(([k, v]) => {
-      if (typeof v === 'string') return { id: k, name: v }
-      if (v && typeof v === 'object') return { id: k, ...(v as any) }
-      return { id: k, name: String(v) }
+      if (typeof v === 'string')
+        return { id: k, name: v, demographics: 'unknown', needs: 'unknown', goals: 'unknown' }
+      if (v && typeof v === 'object') {
+        const {
+          name = '',
+          demographics = 'unknown',
+          needs = 'unknown',
+          goals = 'unknown',
+          ...rest
+        } = v as any
+        return { id: k, name, demographics, needs, goals, ...rest }
+      }
+      return {
+        id: k,
+        name: String(v),
+        demographics: 'unknown',
+        needs: 'unknown',
+        goals: 'unknown',
+      }
     })
   }
 


### PR DESCRIPTION
## Summary
- Default persona demographics, needs, and goals to `unknown` when absent
- Test that personas missing these fields parse with `unknown`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c17fe3f3883298051bcc15fe74c86