### PR TITLE
Fix parsing when NextBestAction is nested in evidence

### DIFF
--- a/interface/src/utils/insightParser.test.ts
+++ b/interface/src/utils/insightParser.test.ts
@@ -41,3 +41,25 @@ test('parses canonical fields', () => {
   })
 })
 
+test('handles NextBestAction nested in evidence', () => {
+  const raw = {
+    insight: {
+      actions: [],
+      evidence: {
+        NextBestAction: { title: 'T', reasoning: 'R', benefit: 'B' },
+        Persona: { id: 'p2', name: 'P2' },
+        evidence: 'E',
+      },
+    },
+    personas: [{ id: 'p1', name: 'P1' }],
+    degraded: false,
+  }
+  const parsed = parseInsightPayload(raw)
+  expect(parsed.actions).toEqual([{ id: '1', title: 'T', reasoning: 'R', benefit: 'B' }])
+  expect(parsed.personas).toEqual([
+    { id: 'p1', name: 'P1', demographics: 'unknown', needs: 'unknown', goals: 'unknown' },
+    { id: 'p2', name: 'P2', demographics: 'unknown', needs: 'unknown', goals: 'unknown' },
+  ])
+  expect(parsed.evidence).toBe('E')
+})
+


### PR DESCRIPTION
## Summary
- normalize `insight.evidence.insights` to always be an array
- move `evidence.NextBestAction` into actions and append `Persona` when actions are otherwise empty
- add regression test for malformed payload parsing

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c33752e1883298f43f025f4535f58