### PR TITLE
Use orchestrator markdown helper for insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ Endpoints:
 
 * `GET /health` – liveness probe.
 * `GET /ready` – always returns `{"ready": true}`.
-* `POST /generate-insights` – body `{"text": "your notes"}` returns `{"insight": "..."}`.
-* `POST /research` – body `{"topic": "AI"}` returns `{"summary": "..."}`.
+* `POST /generate-insights` – body `{"text": "your notes"}` returns `{"markdown": "..."}`.
+* `POST /research` – body `{"topic": "AI"}` returns `{"markdown": "..."}`.
 * `POST /postprocess-report` – body `{"report": {...}}` returns downloads with markdown and CSV.
 * `POST /insight-and-personas` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress" }` returns `{ "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false }`. This endpoint runs the insight and persona prompts concurrently for faster replies.
 
@@ -281,7 +281,7 @@ Expected response:
 
 ```json
 {
-  "summary": "..."
+  "markdown": "..."
 }
 ```
 

--- a/services/insight/README.md
+++ b/services/insight/README.md
@@ -7,8 +7,8 @@ It runs at `http://localhost:8083` when using Docker Compose.
 
 - `GET /health` – liveness probe returning `{ "status": "ok" }`.
 - `GET /ready` – always returns `{ "ready": true }`.
-- `POST /generate-insights` – body `{ "text": "notes" }` returns `{ "insight": "..." }`.
-- `POST /research` – body `{ "topic": "AI" }` returns `{ "summary": "..." }`.
+- `POST /generate-insights` – body `{ "text": "notes" }` returns `{ "markdown": "..." }`.
+- `POST /research` – body `{ "topic": "AI" }` returns `{ "markdown": "..." }`.
 - `POST /postprocess-report` – body `{ "report": {...} }` returns the same report
   plus base64-encoded downloads.
 - `POST /insight-and-personas` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress", "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS" }`
@@ -59,7 +59,7 @@ Expected response snippet:
 
 ```json
 {
-  "summary": "..."
+  "markdown": "..."
 }
 ```
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -370,14 +370,14 @@ def test_insight_success(monkeypatch):
 
     async def handler(request: httpx.Request) -> httpx.Response:
         captured["path"] = request.url.path
-        return httpx.Response(200, json={"insight": "Hi"})
+        return httpx.Response(200, json={"markdown": "Hi"})
 
     transport = httpx.MockTransport(handler)
     _set_mock_transport(monkeypatch, transport)
 
     r = client.post("/insight", json={"text": "Hello"})
     assert r.status_code == 200
-    assert r.json() == {"result": {"insight": "Hi"}, "degraded": False}
+    assert r.json() == {"result": {"markdown": "Hi"}, "degraded": False}
     assert captured["path"] == "/generate-insights"
 
 

--- a/tests/test_insight_retry.py
+++ b/tests/test_insight_retry.py
@@ -15,7 +15,10 @@ def test_retry_rate_limit(monkeypatch):
         attempts["n"] += 1
         if attempts["n"] <= 2:
             return httpx.Response(429)
-        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": '{"markdown": "ok"}'}}]},
+        )
 
     transport = httpx.MockTransport(handler)
 
@@ -46,6 +49,5 @@ def test_retry_rate_limit(monkeypatch):
     r = client.post("/generate-insights", json={"text": "hi"})
     assert r.status_code == 200
     data = r.json()
-    assert data["insight"] == "ok"
-    assert data["degraded"] is False
+    assert data["markdown"] == "ok"
     assert attempts["n"] == 3


### PR DESCRIPTION
## Summary
- call orchestrator.generate_report in /generate-insights and /research
- responses now return markdown only and remove degraded flags
- adjust docs and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ccfb56654832983dd2503d78c8874