### PR TITLE
refactor: streamline insight proxy

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -34,14 +34,14 @@ The interface **requires** `VITE_API_BASE_URL` in `.env` so it knows where the
 API is running. The template now defaults to `http://localhost:8080`. Update
 this value to point at your deployed gateway as needed.
 
-The gateway's `/insight` endpoint calls `/generate-insights` on the insight service.
+The gateway's `/insight` endpoint proxies to `INSIGHT_URL`.
 Make sure `OPENAI_API_KEY` is set in that service's environment so it can reach the OpenAI API.
 
 ## Insight display
 
 The analysis result now includes an "Executive Summary" showing a short
 insight fetched from the gateway. When a user clicks **Generate
-Insights** the frontend calls `/generate-insight-and-personas`.
+Insights** the frontend calls `/insight`.
 `parseInsightPayload` in `src/utils` maps the canonical response fields
 so components consume a consistent structure. The parsed result is then
 passed to `InsightCard` which renders the summary, recommended actions

--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -149,9 +149,9 @@ test('displays insight text', async () => {
 test('shows skeleton while generating', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/generate-insight-and-personas', async () => {
+    http.post('/insight', async () => {
       await new Promise((r) => setTimeout(r, 50))
-      return Response.json({ result: { evidence: 'done', actions: [], personas: [], degraded: false } })
+      return Response.json({ markdown: 'done', degraded: false })
     }),
   )
   render(
@@ -178,7 +178,7 @@ test('shows skeleton while generating', async () => {
 test('shows generated details on success', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/generate-insight-and-personas', async ({ request }) => {
+    http.post('/insight', async ({ request }) => {
       const body = await request.json()
       expect(body).toEqual({
         url: 'https://example.com',
@@ -195,18 +195,7 @@ test('shows generated details on success', async () => {
         audience: ORG_CONTEXT.audience ?? '',
         preferences: ORG_CONTEXT.preferences ?? '',
       })
-      return Response.json({
-        result: {
-          insight: {
-            evidence: 'Flow',
-            actions: {
-              a1: { title: 'Do it', reasoning: 'why', benefit: 'gain' },
-            },
-          },
-          personas: { p1: { name: 'P1', demographics: 'buyer' } },
-          degraded: false,
-        },
-      })
+      return Response.json({ markdown: 'Flow', degraded: false })
     }),
   )
   render(
@@ -227,18 +216,13 @@ test('shows generated details on success', async () => {
   await screen.findByText('Test insight')
   const btn = screen.getByRole('button', { name: /generate insights/i })
   await userEvent.click(btn)
-  await screen.findByText('Do it')
-  screen.getByText('why')
-  screen.getByText('gain')
-  screen.getByText('Flow')
-  screen.getByText('P1')
-  screen.getByText('buyer')
+  await screen.findByText('Flow')
 })
 
 test('shows error when generation fails', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/generate-insight-and-personas', () => new Response(null, { status: 500 }))
+    http.post('/insight', () => new Response(null, { status: 500 }))
   )
   render(
     <AnalyzerCard
@@ -297,9 +281,9 @@ test('shows validation error and skips POST on invalid payload', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   const spy = vi.fn()
   server.use(
-    http.post('/generate-insight-and-personas', () => {
+    http.post('/insight', () => {
       spy()
-      return Response.json({ result: {} })
+      return Response.json({})
     }),
   )
   const badResult: AnalyzeResult = {

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -123,7 +123,7 @@ export default function AnalyzerCard({
         setValidationError(parsed.error.errors.map((e) => e.message).join(', '))
         return
       }
-      const data = await apiFetch<{ result: unknown }>('/generate-insight-and-personas', {
+      const data = await apiFetch<{ markdown?: string; degraded: boolean }>('/insight', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -131,7 +131,7 @@ export default function AnalyzerCard({
           ...(manualCms ? { cms_manual: manualCms } : {}),
         }),
       })
-      setParsedInsight(parseInsightPayload(data.result))
+      setParsedInsight(parseInsightPayload(data))
     } catch (e) {
       setGenError((e as Error).message)
     } finally {

--- a/interface/src/setupTests.ts
+++ b/interface/src/setupTests.ts
@@ -16,12 +16,7 @@ export const server = setupServer(
     }),
   ),
   http.post('/insight', () =>
-    Response.json({ result: { insight: 'Test insight' }, degraded: false }),
-  ),
-  http.post('/generate-insight-and-personas', () =>
-    Response.json({
-      result: { insight: { text: 'Flow' }, personas: { p1: { name: 'P1' } } },
-    }),
+    Response.json({ markdown: 'Test insight', degraded: false }),
   ),
 )
 

--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -157,8 +157,8 @@ async def ready() -> JSONResponse:
 
 
 async def _post_with_retry(
-    url: str, data: dict, service: str
-) -> tuple[dict | None, bool]:
+    url: str, data: dict[str, Any], service: str
+) -> tuple[dict[str, Any] | None, bool]:
     """POST ``data`` to ``url`` with one retry on failure.
 
     Returns a tuple of ``(response_json, degraded)``. ``degraded`` is ``True``
@@ -275,9 +275,11 @@ async def generate(req: GenerateRequest) -> JSONResponse:
 async def insight(data: dict[str, Any]) -> JSONResponse:
     """Proxy insight generation to the insight service."""
     insight_data, degraded = await _post_with_retry(
-        f"{INSIGHT_URL}/generate-insights", data, "insight"
+        INSIGHT_URL, data, "insight"
     )
-    return JSONResponse({"result": insight_data or {}, "degraded": degraded})
+    response = insight_data or {}
+    response["degraded"] = degraded
+    return JSONResponse(response)
 
 
 @app.post("/research")
@@ -289,9 +291,3 @@ async def research(data: dict[str, Any]) -> JSONResponse:
     return JSONResponse({"result": research_data or {}, "degraded": degraded})
 
 
-@app.post("/generate-insight-and-personas")
-async def generate_insight_and_personas(data: dict[str, Any]) -> JSONResponse:
-    result, degraded = await _post_with_retry(
-        f"{INSIGHT_URL}/insight-and-personas", data, "insight"
-    )
-    return JSONResponse({"result": result or {}, "degraded": degraded})

--- a/tests/test_gateway_timeout.py
+++ b/tests/test_gateway_timeout.py
@@ -29,5 +29,5 @@ def test_insight_waits_for_25_seconds(monkeypatch):
     duration = time.perf_counter() - start
 
     assert r.status_code == 200
-    assert r.json() == {"result": {"ok": True}, "degraded": False}
+    assert r.json() == {"ok": True, "degraded": False}
     assert duration >= 25


### PR DESCRIPTION
## Summary
- proxy `/insight` directly to `INSIGHT_URL` and return markdown with degraded flag
- remove `/generate-insight-and-personas` references and docs
- tighten `_post_with_retry` typing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cd639ba208329a417e52795652b39