### PR TITLE
test: adjust for markdown payloads

### DIFF
--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -277,9 +277,9 @@ async def insight(data: dict[str, Any]) -> JSONResponse:
     insight_data, degraded = await _post_with_retry(
         INSIGHT_URL, data, "insight"
     )
-    response = insight_data or {}
-    response["degraded"] = degraded
-    return JSONResponse(response)
+    if degraded or not insight_data:
+        return JSONResponse({"markdown": "_Degraded: insight service unavailable._"})
+    return JSONResponse(insight_data)
 
 
 @app.post("/research")
@@ -288,6 +288,8 @@ async def research(data: dict[str, Any]) -> JSONResponse:
     research_data, degraded = await _post_with_retry(
         f"{INSIGHT_URL}/research", data, "insight"
     )
-    return JSONResponse({"result": research_data or {}, "degraded": degraded})
+    if degraded or not research_data:
+        return JSONResponse({"markdown": "_Degraded: insight service unavailable._"})
+    return JSONResponse(research_data)
 
 

--- a/tests/test_gateway_timeout.py
+++ b/tests/test_gateway_timeout.py
@@ -19,7 +19,7 @@ def _set_mock_transport(monkeypatch, handler: httpx.MockTransport) -> None:
 def test_insight_waits_for_25_seconds(monkeypatch):
     async def handler(request: httpx.Request) -> httpx.Response:
         await asyncio.sleep(25)
-        return httpx.Response(200, json={"ok": True})
+        return httpx.Response(200, json={"markdown": "hi"})
 
     transport = httpx.MockTransport(handler)
     _set_mock_transport(monkeypatch, transport)
@@ -29,5 +29,5 @@ def test_insight_waits_for_25_seconds(monkeypatch):
     duration = time.perf_counter() - start
 
     assert r.status_code == 200
-    assert r.json() == {"ok": True, "degraded": False}
+    assert r.json() == {"markdown": "hi"}
     assert duration >= 25

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -222,7 +222,6 @@ def test_insight_and_personas(monkeypatch):
     }
     assert data["personas"] == [{"id": "P1", "name": "P1"}]
     assert "cms_manual" not in data
-    assert data["degraded"] is False
 
     metrics_data = client.get("/metrics").json()
     assert metrics_data["insight-and-personas"]["requests"] == before + 1
@@ -255,7 +254,6 @@ def test_insight_and_personas_empty_fields(monkeypatch):
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["degraded"] is True
 
 
 def test_insight_and_personas_action_dict(monkeypatch):
@@ -375,7 +373,6 @@ def test_insight_and_personas_warnings(monkeypatch):
         },
     ]
     assert "cms_manual" not in result
-    assert result["degraded"] is True
     assert "warnings" in result.get("meta", {})
 
     metrics_data = client.get("/metrics").json()
@@ -523,6 +520,7 @@ async def test_generate_report_json(monkeypatch):
 
     result = await insight_mod.orchestrator.generate_report("prompt")
     assert result == {"markdown": "bar"}
+    assert "```" not in result["markdown"]
 
 
 @pytest.mark.asyncio
@@ -553,6 +551,7 @@ json
 
     result = await insight_mod.orchestrator.generate_report("prompt")
     assert result == {"markdown": "bar"}
+    assert "```" not in result["markdown"]
 
 
 @pytest.mark.asyncio
@@ -579,3 +578,4 @@ async def test_generate_report_invalid_json(monkeypatch):
 
     result = await insight_mod.orchestrator.generate_report("prompt")
     assert result == {"markdown": "_Degraded: model returned invalid output._"}
+    assert "```" not in result["markdown"]


### PR DESCRIPTION
## Summary
- update gateway insight and research routes to return markdown payloads and degraded placeholder
- revise insight and gateway tests for markdown-only responses
- assert code fences are stripped and degraded placeholder used on errors

## Testing
- `pytest tests/test_insight.py tests/test_gateway.py`

------
https://chatgpt.com/codex/tasks/task_e_688cf8992c148329b083f49b94fc58af