### PR TITLE
Add stable /insight route and proxy error passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The gateway orchestrates the other APIs. Key endpoints:
 * `POST /analyze` – body `{"url": "https://example.com", "headless": false, "force": false}` returns:
   `{"property": {...}, "martech": {...}}`.
 * `POST /generate` – body `{"url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress"}` proxies to the insight service and returns persona and insight JSON.
-* `POST /insight` – body `{"text": "notes"}` proxies to `INSIGHT_URL` and returns `{"markdown": "...", "degraded": false}`.
+* `POST /insight` – body `{"text": "notes"}` proxies to `INSIGHT_URL/insight` and returns `{"markdown": "...", "degraded": false}`.
 * `INSIGHT_TIMEOUT` controls how long the gateway waits for an insight reply (default `30`s).
 
 `MARTECH_URL`, `PROPERTY_URL` and `INSIGHT_URL` configure the upstream URLs used by the gateway.

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -78,13 +78,13 @@ export default function AnalyzerCard({
     const text = result.property?.notes.join('\n') || ''
     setInsightLoading(true)
     setInsightError(null)
-    apiFetch<{ result: { insight?: string } }>('/insight', {
+    apiFetch<{ markdown?: string }>('/insight', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text }),
     })
       .then(async (d) => {
-        const summary = d.result.insight || ''
+        const summary = d.markdown || ''
         setInsight(summary)
       })
       .catch((e) => {

--- a/interface/src/setupTests.ts
+++ b/interface/src/setupTests.ts
@@ -16,7 +16,7 @@ export const server = setupServer(
     }),
   ),
   http.post('/insight', () =>
-    Response.json({ result: { insight: 'Test insight' } }),
+    Response.json({ markdown: 'Test insight' }),
   ),
 )
 

--- a/services/insight/README.md
+++ b/services/insight/README.md
@@ -8,6 +8,8 @@ It runs at `http://localhost:8083` when using Docker Compose.
 - `GET /health` – liveness probe returning `{ "status": "ok" }`.
 - `GET /ready` – always returns `{ "ready": true }`.
 - `POST /generate-insights` – body `{ "text": "notes" }` returns `{ "markdown": "..." }`.
+- `POST /insight` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress" }`
+  returns `{ "markdown": "..." }`.
 - `POST /research` – body `{ "topic": "AI" }` returns `{ "markdown": "..." }`.
 - `POST /postprocess-report` – body `{ "report": {...} }` returns the same report
   plus base64-encoded downloads.

--- a/test-gateway.sh
+++ b/test-gateway.sh
@@ -35,3 +35,10 @@ if [ $? -eq 0 ]; then
 else
   echo "FAIL"
 fi
+
+curl -X POST "$GATEWAY_URL/insight" -d '{"text":"hi"}' -H 'Content-Type: application/json'
+if [ $? -eq 0 ]; then
+  echo "PASS"
+else
+  echo "FAIL"
+fi

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -55,6 +55,33 @@ def test_generate_insights(monkeypatch):
     assert data["markdown"] == "Hello insight"
 
 
+def test_insight_endpoint(monkeypatch):
+    async def fake_report(prompt: str, **_kwargs):
+        return {"markdown": "Hello markdown"}
+
+    monkeypatch.setattr(
+        insight_mod.orchestrator, "generate_report", fake_report, raising=False
+    )
+
+    payload = {"url": "https://ex.com", "martech": {}, "cms": []}
+    r = client.post("/insight", json=payload)
+    assert r.status_code == 200
+    assert r.json()["markdown"] == "Hello markdown"
+
+
+def test_insight_trailing_slash(monkeypatch):
+    async def fake_report(prompt: str, **_kwargs):
+        return {"markdown": "Tolerant"}
+
+    monkeypatch.setattr(
+        insight_mod.orchestrator, "generate_report", fake_report, raising=False
+    )
+
+    r = client.post("/insight/", json={"text": "foo"})
+    assert r.status_code == 200
+    assert r.json()["markdown"] == "Tolerant"
+
+
 def test_research(monkeypatch):
     async def fake_report(prompt: str, **_kwargs):
         return {"markdown": "Research result"}

--- a/tests/test_martech.py
+++ b/tests/test_martech.py
@@ -567,7 +567,7 @@ async def test_startup_fallback(monkeypatch):
     assert services.martech.app.fingerprints == {}
     assert services.martech.app.cms_fingerprints == {}
 
-    async def fake_post(url: str, data: dict, service: str):
+    async def fake_post(url: str, data: dict, service: str, **kwargs):
         if service == "martech":
             resp = client.post("/analyze", json=data)
             return resp.json(), False


### PR DESCRIPTION
## Summary
- add POST `/insight` endpoint in insight service with trailing slash tolerance
- proxy gateway `/insight` to `/insight` on insight service and return upstream errors cleanly
- update frontend to consume `{markdown}` responses and extend smoke tests

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d15d487548329ac50e6320a42ce59