### PR TITLE
feat: add technology stack dictionary

### DIFF
--- a/interface/src/data/stackDictionary.ts
+++ b/interface/src/data/stackDictionary.ts
@@ -1,0 +1,34 @@
+export type StackCategory =
+  | 'Web Platform'
+  | 'Tagging & Analytics'
+  | 'A/B & Personalization'
+  | 'CDP & Event Streaming'
+  | 'Marketing Automation'
+  | 'CRM & RevOps'
+  | 'Data Platform'
+  | 'BI & Activation'
+  | 'Observability & Performance'
+  | 'Cloud & Edge'
+  | 'Ads & Attribution'
+  | 'Security & Consent'
+
+export interface StackVendor {
+  vendor: string
+  category: StackCategory
+  synonyms?: string[]
+}
+
+export const STACK_VENDORS: StackVendor[] = [
+  {
+    vendor: 'Adobe Experience Manager',
+    category: 'Web Platform',
+    synonyms: ['AEM', 'Adobe CQ'],
+  },
+  {
+    vendor: 'Google Analytics 4',
+    category: 'Tagging & Analytics',
+    synonyms: ['GA4', 'Google Analytics', 'GA'],
+  },
+  { vendor: 'Segment', category: 'CDP & Event Streaming' },
+  { vendor: 'Snowflake', category: 'Data Platform' },
+]

--- a/interface/src/utils/stack.test.ts
+++ b/interface/src/utils/stack.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeStackInput } from './stack'
+
+describe('normalizeStackInput', () => {
+  it('resolves synonyms case-insensitively', () => {
+    expect(normalizeStackInput('aem')).toEqual({
+      vendor: 'Adobe Experience Manager',
+      category: 'Web Platform',
+    })
+  })
+
+  it('returns Uncategorized when unknown', () => {
+    expect(normalizeStackInput('MyTool')).toEqual({
+      vendor: 'MyTool',
+      category: 'Uncategorized',
+    })
+  })
+})

--- a/interface/src/utils/stack.ts
+++ b/interface/src/utils/stack.ts
@@ -1,0 +1,17 @@
+import { STACK_VENDORS, StackVendor } from '../data/stackDictionary'
+
+export function normalizeStackInput(
+  input: string
+): StackVendor | { vendor: string; category: 'Uncategorized' } {
+  const trimmed = input.trim()
+  const lower = trimmed.toLowerCase()
+  for (const item of STACK_VENDORS) {
+    if (item.vendor.toLowerCase() === lower) {
+      return { vendor: item.vendor, category: item.category }
+    }
+    if (item.synonyms?.some((s) => s.toLowerCase() === lower)) {
+      return { vendor: item.vendor, category: item.category }
+    }
+  }
+  return { vendor: trimmed, category: 'Uncategorized' }
+}


### PR DESCRIPTION
## Summary
- add typed dictionary for technology stack categories and vendor synonyms
- implement normalizeStackInput helper and tests

## Testing
- `npm --prefix interface test`
- `npm --prefix interface run lint`
- `make lint` *(fails: flake8/mypy errors in existing tests and services)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d84d274108329babc3a068db8e5af