### PR TITLE
feat: add tech stack picker

### DIFF
--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -8,6 +8,7 @@ import { apiFetch } from '../api'
 import { normalizeUrl } from '../utils'
 import { requestSchema } from '../utils/requestSchema'
 import { ORG_CONTEXT } from '../config/orgContext'
+import type { StackItem } from '../utils/tech'
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function computeMartechCount(
@@ -69,7 +70,7 @@ export default function AnalyzerCard({
   const [insightMarkdownDegraded, setInsightMarkdownDegraded] = useState(false)
   const [genError, setGenError] = useState<string | null>(null)
   const [validationError, setValidationError] = useState<string | null>(null)
-  const [techCore, setTechCore] = useState<string[]>(() => {
+  const [techCore, setTechCore] = useState<StackItem[]>(() => {
     try {
       const stored = sessionStorage.getItem('tech_core')
       return stored ? JSON.parse(stored) : []

--- a/interface/src/components/TechnologySelect.tsx
+++ b/interface/src/components/TechnologySelect.tsx
@@ -1,75 +1,34 @@
-import { useState, type SyntheticEvent } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
 import Chip from '@mui/material/Chip'
-import { normalizeTechList } from '../utils/tech'
-
-type Suggestion = { group: string; label: string }
-
-const SUGGESTIONS: Suggestion[] = [
-  { group: 'Core analytics/marketing', label: 'Google Analytics' },
-  { group: 'Core analytics/marketing', label: 'Adobe Analytics' },
-  { group: 'Core analytics/marketing', label: 'Segment' },
-  { group: 'Core analytics/marketing', label: 'Mixpanel' },
-  { group: 'Core analytics/marketing', label: 'Amplitude' },
-  { group: 'Core analytics/marketing', label: 'HubSpot' },
-  { group: 'Core analytics/marketing', label: 'Marketo' },
-  { group: 'Core analytics/marketing', label: 'Salesforce' },
-  { group: 'Core analytics/marketing', label: 'AEM' },
-  { group: 'Core analytics/marketing', label: 'GA4' },
-  { group: 'Core analytics/marketing', label: 'GTM' },
-  { group: 'Core analytics/marketing', label: 'Looker' },
-  { group: 'Core analytics/marketing', label: 'Tableau' },
-  { group: 'Core analytics/marketing', label: 'Snowflake' },
-  { group: 'Core analytics/marketing', label: 'Databricks' },
-  { group: 'Core analytics/marketing', label: 'Shopify' },
-  { group: 'Core analytics/marketing', label: 'BigQuery' },
-  { group: 'Core analytics/marketing', label: 'Redshift' },
-  { group: 'Core analytics/marketing', label: 'Braze' },
-  { group: 'Core analytics/marketing', label: 'Iterable' },
-]
+import { SUGGESTIONS, type StackItem } from '../utils/tech'
 
 type TechnologySelectProps = {
-  value: string[]
-  onChange: (v: string[]) => void
+  value: StackItem[]
+  onChange: (v: StackItem[]) => void
 }
 
 export default function TechnologySelect({ value, onChange }: TechnologySelectProps) {
-  const [showEmptyNote, setShowEmptyNote] = useState(false)
-
-  function handleChange(
-    _: SyntheticEvent,
-    newValue: (string | Suggestion)[],
-  ) {
-    const mapped = newValue.map((v) => (typeof v === 'string' ? v : v.label))
-    const normalized = normalizeTechList(mapped)
-    setShowEmptyNote(mapped.some((v) => !v || !v.trim()))
-    onChange(normalized)
-  }
-
   return (
     <div className="mt-4">
-      <Autocomplete<Suggestion, true, false, true>
+      <Autocomplete<StackItem, true, false, false>
         multiple
-        freeSolo
         options={SUGGESTIONS}
-        groupBy={(option) => option.group}
-        getOptionLabel={(option) => (typeof option === 'string' ? option : option.label)}
+        groupBy={(option) => option.category}
+        getOptionLabel={(option) => option.vendor}
         value={value}
-        onChange={handleChange}
+        onChange={(_, newValue) => onChange(newValue)}
+        isOptionEqualToValue={(option, val) => option.vendor === val.vendor}
         renderTags={(tagValue, getTagProps) =>
           tagValue.map((option, index) => (
             <Chip
               {...getTagProps({ index })}
-              label={typeof option === 'string' ? option : option.label}
+              label={`${option.category} • ${option.vendor}`}
             />
           ))
         }
         renderInput={(params) => <TextField {...params} label="Technologies in use" />}
       />
-      {showEmptyNote && (
-        <div className="text-sm text-red-600 mt-1">Empty value ignored</div>
-      )}
     </div>
   )
 }

--- a/interface/src/components/index.ts
+++ b/interface/src/components/index.ts
@@ -14,4 +14,5 @@ export {
   default as InsightMarkdown,
   type InsightMarkdownProps,
 } from './InsightMarkdown'
+export { default as TechnologySelect } from './TechnologySelect'
 

--- a/interface/src/utils/tech.test.ts
+++ b/interface/src/utils/tech.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeTechList } from './tech'
+import { normalizeTechList, normalizeStack } from './tech'
 
 describe('normalizeTechList', () => {
   it('trims, dedupes case-insensitively, and removes empty', () => {
@@ -9,5 +9,20 @@ describe('normalizeTechList', () => {
 
   it('coerces falsy values to empty array', () => {
     expect(normalizeTechList([undefined, null, '  '])).toEqual([])
+  })
+})
+
+describe('normalizeStack', () => {
+  it('maps aliases, assigns categories, and dedupes case-insensitively', () => {
+    const input = ['ga', 'AEM', 'GA4', 'GTM', 'google tag manager']
+    expect(normalizeStack(input)).toEqual([
+      { category: 'Tagging & Analytics', vendor: 'Google Analytics 4' },
+      { category: 'Web Platform', vendor: 'Adobe Experience Manager' },
+      { category: 'Tagging & Analytics', vendor: 'Google Tag Manager' },
+    ])
+  })
+
+  it('coerces falsy values to empty array', () => {
+    expect(normalizeStack([undefined, null, '  '])).toEqual([])
   })
 })

--- a/interface/src/utils/tech.ts
+++ b/interface/src/utils/tech.ts
@@ -1,15 +1,92 @@
-export function normalizeTechList(list: (string | null | undefined)[]): string[] {
-  const result: string[] = [];
-  const seen = new Set<string>();
+export type StackItem = { category: string; vendor: string }
+
+export const SUGGESTIONS: StackItem[] = [
+  { category: 'Web Platform', vendor: 'Adobe Experience Manager' },
+  { category: 'Web Platform', vendor: 'WordPress' },
+  { category: 'Web Platform', vendor: 'Drupal' },
+  { category: 'Web Platform', vendor: 'Shopify' },
+  { category: 'Web Platform', vendor: 'Webflow' },
+
+  { category: 'Tagging & Analytics', vendor: 'Google Analytics 4' },
+  { category: 'Tagging & Analytics', vendor: 'Google Tag Manager' },
+  { category: 'Tagging & Analytics', vendor: 'Adobe Analytics' },
+  { category: 'Tagging & Analytics', vendor: 'Mixpanel' },
+  { category: 'Tagging & Analytics', vendor: 'Amplitude' },
+
+  { category: 'CDP & Event Streaming', vendor: 'Segment' },
+  { category: 'CDP & Event Streaming', vendor: 'mParticle' },
+  { category: 'CDP & Event Streaming', vendor: 'RudderStack' },
+  { category: 'CDP & Event Streaming', vendor: 'Kafka' },
+  { category: 'CDP & Event Streaming', vendor: 'Snowplow' },
+
+  { category: 'Marketing Automation', vendor: 'HubSpot' },
+  { category: 'Marketing Automation', vendor: 'Marketo' },
+  { category: 'Marketing Automation', vendor: 'Braze' },
+  { category: 'Marketing Automation', vendor: 'Iterable' },
+  { category: 'Marketing Automation', vendor: 'Customer.io' },
+
+  { category: 'CRM & RevOps', vendor: 'Salesforce' },
+  { category: 'CRM & RevOps', vendor: 'HubSpot CRM' },
+  { category: 'CRM & RevOps', vendor: 'Pipedrive' },
+  { category: 'CRM & RevOps', vendor: 'Zoho CRM' },
+  { category: 'CRM & RevOps', vendor: 'Close' },
+
+  { category: 'Data Platform', vendor: 'Snowflake' },
+  { category: 'Data Platform', vendor: 'Databricks' },
+  { category: 'Data Platform', vendor: 'BigQuery' },
+  { category: 'Data Platform', vendor: 'Redshift' },
+  { category: 'Data Platform', vendor: 'PostgreSQL' },
+
+  { category: 'BI & Activation', vendor: 'Looker' },
+  { category: 'BI & Activation', vendor: 'Tableau' },
+  { category: 'BI & Activation', vendor: 'Power BI' },
+  { category: 'BI & Activation', vendor: 'Mode' },
+  { category: 'BI & Activation', vendor: 'Hightouch' },
+]
+
+const ALIASES: Record<string, string> = {
+  aem: 'Adobe Experience Manager',
+  ga: 'Google Analytics 4',
+  ga4: 'Google Analytics 4',
+  'google analytics': 'Google Analytics 4',
+  gtm: 'Google Tag Manager',
+  'google tag manager': 'Google Tag Manager',
+}
+
+const VENDOR_CATEGORY = SUGGESTIONS.reduce<Record<string, string>>((acc, cur) => {
+  acc[cur.vendor.toLowerCase()] = cur.category
+  return acc
+}, {})
+
+export function normalizeStack(list: (string | null | undefined)[]): StackItem[] {
+  const result: StackItem[] = []
+  const seen = new Set<string>()
   for (const item of list) {
-    if (!item) continue;
-    const trimmed = item.trim();
-    if (!trimmed) continue;
-    const key = trimmed.toLowerCase();
+    if (!item) continue
+    const trimmed = item.trim()
+    if (!trimmed) continue
+    const canonical = ALIASES[trimmed.toLowerCase()] ?? trimmed
+    const key = canonical.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    const category = VENDOR_CATEGORY[key] || 'Other'
+    result.push({ category, vendor: canonical })
+  }
+  return result
+}
+
+export function normalizeTechList(list: (string | null | undefined)[]): string[] {
+  const result: string[] = []
+  const seen = new Set<string>()
+  for (const item of list) {
+    if (!item) continue
+    const trimmed = item.trim()
+    if (!trimmed) continue
+    const key = trimmed.toLowerCase()
     if (!seen.has(key)) {
-      seen.add(key);
-      result.push(trimmed);
+      seen.add(key)
+      result.push(trimmed)
     }
   }
-  return result;
+  return result
 }


### PR DESCRIPTION
## Summary
- add normalizeStack helper with curated tech suggestions and alias mapping
- replace TechnologySelect with multi-select returning {category, vendor} and wire AnalyzerCard to it
- export new TechnologySelect

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d8985cc6c8329b469908c86e5e638