### PR TITLE
feat: add industry and stack fields

### DIFF
--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -122,7 +122,6 @@ test('shows CMS placeholder when array empty', async () => {
     name: 'Content Management Systems',
   }).parentElement as HTMLElement
   expect(within(cmsSection).getByText('Nothing detected')).toBeInTheDocument()
-  expect(within(cmsSection).getByLabelText('CMS')).toBeInTheDocument()
 })
 
 test('displays insight text', async () => {
@@ -189,9 +188,9 @@ test('shows generated details on success', async () => {
           competitors: (result.martech as any)?.competitors ?? [],
         },
         cms: [],
-        tech_core: [],
-        tech_adjacent: [],
-        tech_broader: [],
+        industry: '',
+        pain_point: '',
+        stack: [],
         evidence_standards: ORG_CONTEXT.evidence_standards ?? '',
         credibility_scoring: ORG_CONTEXT.credibility_scoring ?? '',
         deliverable_guidelines: ORG_CONTEXT.deliverable_guidelines ?? '',

--- a/interface/src/components/CmsResults.tsx
+++ b/interface/src/components/CmsResults.tsx
@@ -1,10 +1,8 @@
 type Props = {
   cms: string[]
-  manualCms?: string
-  setManualCms?: (v: string) => void
 }
 
-export default function CmsResults({ cms, manualCms, setManualCms }: Props) {
+export default function CmsResults({ cms }: Props) {
   function renderList(items: string[]) {
     if (!items || items.length === 0) {
       return <p className="italic">Nothing detected</p>
@@ -20,31 +18,7 @@ export default function CmsResults({ cms, manualCms, setManualCms }: Props) {
   return (
     <div className="bg-gray-50 p-4 rounded">
       <h3 className="font-medium mb-2">Content Management Systems</h3>
-      {cms.length > 0 ? (
-        renderList(cms)
-      ) : (
-        <div>
-          {renderList(cms)}
-          {setManualCms && (
-            <div className="mt-2">
-              <input
-                aria-label="CMS"
-                list="cms-list"
-                value={manualCms}
-                onChange={(e) => setManualCms(e.target.value)}
-                placeholder="Enter CMS"
-                className="border rounded p-2 w-full"
-              />
-              <datalist id="cms-list">
-                <option value="WordPress" />
-                <option value="Drupal" />
-                <option value="Adobe Experience Manager" />
-                <option value="Shopify" />
-              </datalist>
-            </div>
-          )}
-        </div>
-      )}
+      {renderList(cms)}
     </div>
   )
 }

--- a/interface/src/utils/requestSchema.ts
+++ b/interface/src/utils/requestSchema.ts
@@ -9,9 +9,12 @@ export const requestSchema = z.object({
     competitors: z.array(z.string()),
   }),
   cms: z.array(z.string()),
-  tech_core: z.array(z.string()).optional().default([]),
-  tech_adjacent: z.array(z.string()).optional().default([]),
-  tech_broader: z.array(z.string()).optional().default([]),
+  industry: z.string().max(1024).optional(),
+  pain_point: z.string().max(1024).optional(),
+  stack: z
+    .array(z.object({ category: z.string(), vendor: z.string() }))
+    .optional()
+    .default([]),
   evidence_standards: z.string().max(1024),
   credibility_scoring: z.string().max(1024),
   deliverable_guidelines: z.string().max(1024),


### PR DESCRIPTION
## Summary
- add industry, pain point, and stack fields with session storage persistence
- include new fields in insight generation request and drop manual CMS UI
- allow CMS results to display without manual input

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d8bd4c988832995bbdca5c88addcc