### PR TITLE
feat: allow exporting markdown

### DIFF
--- a/interface/src/components/InsightMarkdown.test.tsx
+++ b/interface/src/components/InsightMarkdown.test.tsx
@@ -23,9 +23,19 @@ test('shows skeleton when loading', () => {
 test('shows fallback when markdown empty', () => {
   render(<InsightMarkdown markdown="" />)
   expect(screen.getByText('Analysis unavailable')).toBeInTheDocument()
+  expect(
+    screen.queryByRole('button', { name: /export markdown/i }),
+  ).toBeNull()
 })
 
 test('shows degraded banner', () => {
   render(<InsightMarkdown markdown="# H" degraded />)
   expect(screen.getByText(/Partial results/)).toBeInTheDocument()
+})
+
+test('shows export button when markdown provided', () => {
+  render(<InsightMarkdown markdown="# H" />)
+  expect(
+    screen.getByRole('button', { name: /export markdown/i }),
+  ).toBeInTheDocument()
 })

--- a/interface/src/components/InsightMarkdown.tsx
+++ b/interface/src/components/InsightMarkdown.tsx
@@ -22,8 +22,19 @@ export default function InsightMarkdown({ markdown, loading = false, degraded = 
   }
 
   const sanitized = DOMPurify.sanitize(markdown)
+  const hasContent = sanitized.trim().length > 0
 
-  const content = sanitized.trim()
+  const handleExport = () => {
+    const blob = new Blob([markdown], { type: 'text/markdown' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = 'insight.md'
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const content = hasContent
     ? <MarkdownPreview source={sanitized} className="prose max-w-none" />
     : <p>Analysis unavailable</p>
 
@@ -33,6 +44,13 @@ export default function InsightMarkdown({ markdown, loading = false, degraded = 
         <div className="border border-yellow-500 bg-yellow-50 text-yellow-700 p-2 rounded mb-2 text-sm">
           Partial results shown due to degraded analysis.
         </div>
+      )}
+      {hasContent && (
+        <CardContent className="flex justify-end pt-0">
+          <button onClick={handleExport} className="btn-primary">
+            Export Markdown
+          </button>
+        </CardContent>
       )}
       <CardContent>{content}</CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- add optional export button to InsightMarkdown
- handle click to download markdown as .md file
- test export button visibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d91f1764c8329a5d925a33930fa42