### PR TITLE
docs: document new analyzer inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,12 @@ clients can detect limited results.
 
 The React interface displays each insight using a reusable **InsightCard**. This
 component accepts the normalized insight payload from the backend and renders
-the evidence, recommended actions and any personas in a single card. Markdown
+the evidence, recommended actions and any personas in a single card. The
+analyzer captures optional **Industry**, **Pain Point**, and declared
+**Technology Stack** details that are passed along with the URL. Markdown
 fragments are styled via the Tailwind Typography plugin so the text appears
-nicely formatted.
+nicely formatted, and an **Export Markdown** button lets users download the
+analysis.
 
 ### Gateway service
 The gateway orchestrates the other APIs. Key endpoints:
@@ -105,7 +108,7 @@ The gateway orchestrates the other APIs. Key endpoints:
 * `POST /analyze` – body `{"url": "https://example.com", "headless": false, "force": false}` returns:
   `{"property": {...}, "martech": {...}}`.
 * `POST /generate` – body `{"url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress"}` proxies to the insight service and returns persona and insight JSON.
-* `POST /insight` – body `{"text": "notes"}` proxies to `INSIGHT_URL/insight` and returns `{"markdown": "...", "degraded": false}`.
+* `POST /insight` – body `{ "url": "https://example.com", "industry": "SaaS", "pain_point": "Slow onboarding", "stack": [{"category": "analytics", "vendor": "GA4"}] }` proxies to `INSIGHT_URL/insight` and returns `{ "markdown": "...", "degraded": false }`. The endpoint also accepts `{ "text": "notes" }` for free‑form analysis.
 * `INSIGHT_TIMEOUT` controls how long the gateway waits for an insight reply (default `30`s).
 
 `MARTECH_URL`, `PROPERTY_URL` and `INSIGHT_URL` configure the upstream URLs used by the gateway.
@@ -211,9 +214,10 @@ Endpoints:
 * `GET /health` – liveness probe.
 * `GET /ready` – always returns `{"ready": true}`.
 * `POST /generate-insights` – body `{"text": "your notes"}` returns `{"markdown": "..."}`.
+* `POST /insight` – body `{ "url": "https://example.com", "industry": "SaaS", "pain_point": "Slow onboarding", "stack": [{"category": "analytics", "vendor": "GA4"}] }` returns `{ "markdown": "..." }`.
 * `POST /research` – body `{"topic": "AI"}` returns `{"markdown": "..."}`.
 * `POST /postprocess-report` – body `{"report": {...}}` returns downloads with markdown and CSV.
-* `POST /insight-and-personas` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress" }` returns `{ "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false }`. This endpoint runs the insight and persona prompts concurrently for faster replies.
+* `POST /insight-and-personas` – body `{ "url": "https://example.com", "industry": "SaaS", "pain_point": "Slow onboarding", "stack": [{"category": "analytics", "vendor": "GA4"}], "martech": {...}, "cms": [], "cms_manual": "WordPress" }` returns `{ "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false }`. This endpoint runs the insight and persona prompts concurrently for faster replies.
 
 Set `OPENAI_MODEL` to choose the chat model (default `gpt-4`).
 Set `MACRO_SECTION_CAP` to cap macro sections returned by `/research`.

--- a/interface/README.md
+++ b/interface/README.md
@@ -20,6 +20,10 @@ npm run dev
 
 Open `http://localhost:5173` in your browser and start analyzing URLs.
 
+The analyzer form includes a **Technology Stack** picker, an **Industry**
+dropdown, and a **Pain Point** text box for additional context. Generated
+insights can be downloaded via the **Export Markdown** button.
+
 ## Building and running
 
 ```bash

--- a/interface/src/components/TechnologySelect.tsx
+++ b/interface/src/components/TechnologySelect.tsx
@@ -3,7 +3,7 @@ import TextField from '@mui/material/TextField'
 import Chip from '@mui/material/Chip'
 import { SUGGESTIONS, type StackItem } from '../utils/tech'
 
-type TechnologySelectProps = {
+export type TechnologySelectProps = {
   value: StackItem[]
   onChange: (v: StackItem[]) => void
 }

--- a/interface/src/components/index.ts
+++ b/interface/src/components/index.ts
@@ -14,5 +14,8 @@ export {
   default as InsightMarkdown,
   type InsightMarkdownProps,
 } from './InsightMarkdown'
-export { default as TechnologySelect } from './TechnologySelect'
+export {
+  default as TechnologySelect,
+  type TechnologySelectProps,
+} from './TechnologySelect'
 

--- a/services/insight/README.md
+++ b/services/insight/README.md
@@ -8,12 +8,12 @@ It runs at `http://localhost:8083` when using Docker Compose.
 - `GET /health` – liveness probe returning `{ "status": "ok" }`.
 - `GET /ready` – always returns `{ "ready": true }`.
 - `POST /generate-insights` – body `{ "text": "notes" }` returns `{ "markdown": "..." }`.
-- `POST /insight` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress" }`
+- `POST /insight` – body `{ "url": "https://example.com", "industry": "SaaS", "pain_point": "Slow onboarding", "stack": [{"category": "analytics", "vendor": "GA4"}] }`
   returns `{ "markdown": "..." }`.
 - `POST /research` – body `{ "topic": "AI" }` returns `{ "markdown": "..." }`.
 - `POST /postprocess-report` – body `{ "report": {...} }` returns the same report
   plus base64-encoded downloads.
-- `POST /insight-and-personas` – body `{ "url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress", "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS" }`
+- `POST /insight-and-personas` – body `{ "url": "https://example.com", "industry": "SaaS", "pain_point": "Slow onboarding", "stack": [{"category": "analytics", "vendor": "GA4"}], "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS" }`
   returns { "insight": {"actions": [...], "evidence": "..."}, "personas": [{"id": "P1"}], "cms_manual": "WordPress", "degraded": false }. Insight and persona prompts run concurrently. The `evidence` field summarizing findings is always included. If the persona response is empty, placeholder company and technology personas are created with all attributes set to "unknown". The gateway will return a timeout after 20s if the insight service is slow. The optional fields fine‑tune how the report is generated.
 - `GET /metrics` – usage counters for requests and data gaps.
 
@@ -70,7 +70,7 @@ Example (insight and personas):
 ```bash
 curl -X POST http://localhost:8083/insight-and-personas \
   -H 'Content-Type: application/json' \
-  -d '{"url": "https://example.com", "martech": {}, "cms": [], "cms_manual": "WordPress", "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS"}'
+  -d '{"url": "https://example.com", "industry": "SaaS", "pain_point": "Slow onboarding", "stack": [{"category": "analytics", "vendor": "GA4"}], "evidence_standards": "Use peer-reviewed data", "credibility_scoring": "1-5", "deliverable_guidelines": "Plain language", "audience": "CTO", "preferences": "Focus on OSS"}'
 ```
 
 Expected response snippet:
@@ -79,7 +79,6 @@ Expected response snippet:
 {
   "insight": { "actions": [], "evidence": "..." },
   "personas": [{"id": "P1", "name": "Buyer", "role": "unknown", "goal": "unknown", "challenge": "unknown"}],
-  "cms_manual": "WordPress",
   "degraded": false
 }
 ```


### PR DESCRIPTION
## Summary
- describe new Technology Stack picker, Industry dropdown, Pain Point input and Markdown export
- export TechnologySelect and its props from component index
- note `industry`, `pain_point` and `stack` fields for insight endpoints

## Testing
- `npm run lint --prefix interface` *(fails: Unexpected any. Specify a different type)*
- `npm test --prefix interface`
- `make lint` *(fails: flake8/mypy errors)*
- `make test` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*


------
https://chatgpt.com/codex/tasks/task_e_688d9ca3d9848329a7d3152a6cd02c1f