### PR TITLE
feat: banner for degraded insights

### DIFF
--- a/interface/src/components/InsightMarkdown.test.tsx
+++ b/interface/src/components/InsightMarkdown.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { render, screen } from '@testing-library/react'
 import { test, expect, vi } from 'vitest'
 import userEvent from '@testing-library/user-event'
@@ -30,9 +31,9 @@ test('skeleton has fixed min-height', () => {
   )
 })
 
-test('shows fallback when markdown empty', () => {
+test('renders empty markdown without export button', () => {
   render(<InsightMarkdown markdown="" />)
-  expect(screen.getByText('Analysis unavailable')).toBeInTheDocument()
+  expect(screen.queryByText('Analysis unavailable')).toBeNull()
   expect(
     screen.queryByRole('button', { name: /export markdown/i }),
   ).toBeNull()

--- a/interface/src/components/InsightMarkdown.tsx
+++ b/interface/src/components/InsightMarkdown.tsx
@@ -47,10 +47,6 @@ export default function InsightMarkdown({
     URL.revokeObjectURL(url)
   }
 
-  const content = hasContent
-    ? <MarkdownPreview source={sanitized} className="prose max-w-none" />
-    : <p>Analysis unavailable</p>
-
   return (
     <Card className="space-y-4">
       {degraded && (
@@ -65,7 +61,9 @@ export default function InsightMarkdown({
           </button>
         </CardContent>
       )}
-      <CardContent>{content}</CardContent>
+      <CardContent>
+        <MarkdownPreview source={sanitized} className="prose max-w-none" />
+      </CardContent>
     </Card>
   )
 }


### PR DESCRIPTION
## Summary
- flag missing "Next-Best Actions" in analyzer insights and show a limited-content banner with nudge to add context via sheet panel
- always render provided insight markdown, dropping fallback text
- test analyzer banner logic and context panel behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688db537b69483299179d3e6805477eb