### PR TITLE
feat: add context chips and strength indicator

### DIFF
--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -532,3 +532,136 @@ test('shows validation error and skips POST on invalid payload', async () => {
   await screen.findByText(/Expected string/i)
   expect(spy).not.toHaveBeenCalled()
 })
+
+test('chips reflect live values', async () => {
+  sessionStorage.setItem('industry', 'SaaS')
+  sessionStorage.setItem('pain_point', 'Latency')
+  sessionStorage.setItem(
+    'stack',
+    JSON.stringify([
+      { category: 'x', vendor: 'one' },
+      { category: 'y', vendor: 'two' },
+    ]),
+  )
+  const { default: AnalyzerCard } = await import('./AnalyzerCard')
+  render(
+    <AnalyzerCard
+      id="a"
+      url="example.com"
+      setUrl={() => {}}
+      onAnalyze={() => {}}
+      headless={false}
+      setHeadless={() => {}}
+      force={false}
+      setForce={() => {}}
+      loading={false}
+      error=""
+      result={{ ...result, cms: [] }}
+    />,
+  )
+  await screen.findByText('SaaS')
+  await screen.findByText('Latency')
+  await screen.findByText('Stack (2)')
+  const industryChip = screen.getByText('SaaS')
+  await userEvent.click(industryChip)
+  const industryInput = await screen.findByLabelText('Industry')
+  await userEvent.clear(industryInput)
+  await userEvent.type(industryInput, 'Commerce')
+  await waitFor(() => expect(screen.getByText('Commerce')).toBeInTheDocument())
+  await userEvent.click(screen.getByLabelText('close'))
+  const painChip = screen.getByText('Latency')
+  await userEvent.click(painChip)
+  const painInput = await screen.findByLabelText('Pain point')
+  await userEvent.clear(painInput)
+  await waitFor(() => expect(screen.queryByText('Latency')).toBeNull())
+  sessionStorage.clear()
+})
+
+test('chip clicks focus corresponding inputs', async () => {
+  sessionStorage.setItem('industry', 'Fintech')
+  sessionStorage.setItem('pain_point', 'Billing')
+  sessionStorage.setItem(
+    'stack',
+    JSON.stringify([
+      { category: 'x', vendor: 'one' },
+      { category: 'y', vendor: 'two' },
+    ]),
+  )
+  const { default: AnalyzerCard } = await import('./AnalyzerCard')
+  render(
+    <AnalyzerCard
+      id="a"
+      url="example.com"
+      setUrl={() => {}}
+      onAnalyze={() => {}}
+      headless={false}
+      setHeadless={() => {}}
+      force={false}
+      setForce={() => {}}
+      loading={false}
+      error=""
+      result={{ ...result, cms: [] }}
+    />,
+  )
+  const industryChip = await screen.findByText('Fintech')
+  await userEvent.click(industryChip)
+  const industryInput = await screen.findByLabelText('Industry')
+  await waitFor(() => expect(industryInput).toHaveFocus())
+  await userEvent.click(screen.getByLabelText('close'))
+  const painChip = screen.getByText('Billing')
+  await userEvent.click(painChip)
+  const painInput = await screen.findByLabelText('Pain point')
+  await waitFor(() => expect(painInput).toHaveFocus())
+  await userEvent.click(screen.getByLabelText('close'))
+  const stackChip = screen.getByText('Stack (2)')
+  await userEvent.click(stackChip)
+  const stackInput = await screen.findByLabelText('Technologies in use')
+  await waitFor(() => expect(stackInput).toHaveFocus())
+  sessionStorage.clear()
+})
+
+test('context strength updates with field edits', async () => {
+  sessionStorage.setItem('industry', 'Fintech')
+  sessionStorage.setItem('pain_point', 'Billing')
+  sessionStorage.setItem(
+    'stack',
+    JSON.stringify([
+      { category: 'x', vendor: 'one' },
+      { category: 'y', vendor: 'two' },
+      { category: 'z', vendor: 'three' },
+    ]),
+  )
+  const { default: AnalyzerCard } = await import('./AnalyzerCard')
+  render(
+    <AnalyzerCard
+      id="a"
+      url="example.com"
+      setUrl={() => {}}
+      onAnalyze={() => {}}
+      headless={false}
+      setHeadless={() => {}}
+      force={false}
+      setForce={() => {}}
+      loading={false}
+      error=""
+      result={{ ...result, cms: [] }}
+    />,
+  )
+  await screen.findByText('Context strength: High')
+  const industryChip = screen.getByText('Fintech')
+  await userEvent.click(industryChip)
+  const industryInput = await screen.findByLabelText('Industry')
+  await userEvent.clear(industryInput)
+  await waitFor(() =>
+    expect(screen.getByText('Context strength: Medium')).toBeInTheDocument(),
+  )
+  await userEvent.click(screen.getByLabelText('close'))
+  const painChip = screen.getByText('Billing')
+  await userEvent.click(painChip)
+  const painInput = await screen.findByLabelText('Pain point')
+  await userEvent.clear(painInput)
+  await waitFor(() =>
+    expect(screen.getByText('Context strength: Low')).toBeInTheDocument(),
+  )
+  sessionStorage.clear()
+})

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, type RefObject } from 'react'
 import PropertyResults from './PropertyResults'
 import MartechResults from './MartechResults'
 import CmsResults from './CmsResults'
@@ -97,6 +97,10 @@ export default function AnalyzerCard({
     }
   })
   const [contextOpen, setContextOpen] = useState(false)
+  const [, setHasGenerated] = useState(false)
+  const industryRef = useRef<HTMLInputElement>(null)
+  const painRef = useRef<HTMLInputElement>(null)
+  const stackRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     sessionStorage.setItem('industry', industry)
@@ -185,11 +189,24 @@ export default function AnalyzerCard({
       })
       setInsightMarkdown((data.markdown ?? '').trim())
       setInsightMarkdownDegraded(data.degraded)
+      setHasGenerated(true)
     } catch (e) {
       setGenError((e as Error).message)
     } finally {
       setGenerating(false)
     }
+  }
+  const stackCount = stack.length
+  const filled = (industry ? 1 : 0) + (painPoint ? 1 : 0) + (stackCount ? 1 : 0)
+  const contextStrength =
+    industry && painPoint && stackCount >= 3
+      ? 'High'
+      : filled >= 2
+        ? 'Medium'
+        : 'Low'
+  function focusRef(ref: RefObject<HTMLInputElement | null>) {
+    setContextOpen(true)
+    setTimeout(() => ref.current?.focus(), 0)
   }
   const actionsMissing = insightMarkdown !== null && !hasNextBestActions(insightMarkdown)
   const showDegradedBanner =
@@ -284,6 +301,45 @@ export default function AnalyzerCard({
         )}
         {cms && cms.length === 0 && (
           <>
+            <div className="mt-4">
+              <div className="flex flex-wrap gap-2">
+                {industry && (
+                  <button
+                    className="border rounded-full px-2 py-0.5 text-xs"
+                    onClick={() => focusRef(industryRef)}
+                  >
+                    {industry}
+                  </button>
+                )}
+                {painPoint && (
+                  <button
+                    className="border rounded-full px-2 py-0.5 text-xs"
+                    onClick={() => focusRef(painRef)}
+                  >
+                    {painPoint}
+                  </button>
+                )}
+                {stackCount > 0 && (
+                  <button
+                    className="border rounded-full px-2 py-0.5 text-xs"
+                    onClick={() => focusRef(stackRef)}
+                  >
+                    {`Stack (${stackCount})`}
+                  </button>
+                )}
+                {!industry && !painPoint && stackCount === 0 && (
+                  <button
+                    className="border rounded-full px-2 py-0.5 text-xs"
+                    onClick={() => setContextOpen(true)}
+                  >
+                    Add context
+                  </button>
+                )}
+              </div>
+              <div className="text-xs text-gray-600 mt-1">
+                Context strength: {contextStrength}
+              </div>
+            </div>
             <button
               className="btn-primary mt-4"
               disabled={generating || insightLoading}
@@ -319,6 +375,7 @@ export default function AnalyzerCard({
                   onChange={(e) => setIndustry(e.target.value)}
                   placeholder="Industry"
                   className="border rounded p-2 w-full"
+                  ref={industryRef}
                 />
                 <input
                   aria-label="Pain point"
@@ -326,8 +383,13 @@ export default function AnalyzerCard({
                   onChange={(e) => setPainPoint(e.target.value)}
                   placeholder="Pain point"
                   className="border rounded p-2 w-full"
+                  ref={painRef}
                 />
-                <TechnologySelect value={stack} onChange={setStack} />
+                <TechnologySelect
+                  value={stack}
+                  onChange={setStack}
+                  inputRef={stackRef}
+                />
               </div>
             </Sheet>
             {validationError && (

--- a/interface/src/components/TechnologySelect.tsx
+++ b/interface/src/components/TechnologySelect.tsx
@@ -1,14 +1,20 @@
 import Autocomplete from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
 import Chip from '@mui/material/Chip'
+import { type Ref } from 'react'
 import { SUGGESTIONS, type StackItem } from '../utils/tech'
 
 export type TechnologySelectProps = {
   value: StackItem[]
   onChange: (v: StackItem[]) => void
+  inputRef?: Ref<HTMLInputElement>
 }
 
-export default function TechnologySelect({ value, onChange }: TechnologySelectProps) {
+export default function TechnologySelect({
+  value,
+  onChange,
+  inputRef,
+}: TechnologySelectProps) {
   return (
     <div className="mt-4">
       <Autocomplete<StackItem, true, false, false>
@@ -20,14 +26,24 @@ export default function TechnologySelect({ value, onChange }: TechnologySelectPr
         onChange={(_, newValue) => onChange(newValue)}
         isOptionEqualToValue={(option, val) => option.vendor === val.vendor}
         renderTags={(tagValue, getTagProps) =>
-          tagValue.map((option, index) => (
-            <Chip
-              {...getTagProps({ index })}
-              label={`${option.category} • ${option.vendor}`}
-            />
-          ))
+          tagValue.map((option, index) => {
+            const { key, ...chipProps } = getTagProps({ index })
+            return (
+              <Chip
+                key={key}
+                {...chipProps}
+                label={`${option.category} • ${option.vendor}`}
+              />
+            )
+          })
         }
-        renderInput={(params) => <TextField {...params} label="Technologies in use" />}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label="Technologies in use"
+            inputRef={inputRef}
+          />
+        )}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- show context chips after analysis and compute strength levels
- add focusable references for industry, pain, and stack inputs
- test chips, focus behavior, and context strength updates
- allow context editing before generating insights
- fix chip key usage and ensure generation flag is tracked

## Testing
- `cd interface && npm ci`
- `cd interface && npm test`
- `cd interface && npm run build`
- `cd interface && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e7d41796c8329a04c01f154d5b5c4