### PR TITLE
Fix context chips flow before insight request

### DIFF
--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -564,9 +564,6 @@ test('chips reflect live values', async () => {
       result={{ ...result, cms: [] }}
     />,
   )
-  const btn = await screen.findByRole('button', { name: /generate insights/i })
-  await waitFor(() => expect(btn).toBeEnabled())
-  await userEvent.click(btn)
   await screen.findByText('SaaS')
   await screen.findByText('Latency')
   await screen.findByText('Stack (2)')
@@ -616,9 +613,6 @@ test('chip clicks focus corresponding inputs', async () => {
       result={{ ...result, cms: [] }}
     />,
   )
-  const btn = await screen.findByRole('button', { name: /generate insights/i })
-  await waitFor(() => expect(btn).toBeEnabled())
-  await userEvent.click(btn)
   const industryChip = await screen.findByText('Fintech')
   await userEvent.click(industryChip)
   const industryInput = await screen.findByLabelText('Industry')
@@ -668,9 +662,6 @@ test('context strength updates with field edits', async () => {
       result={{ ...result, cms: [] }}
     />,
   )
-  const btn = await screen.findByRole('button', { name: /generate insights/i })
-  await waitFor(() => expect(btn).toBeEnabled())
-  await userEvent.click(btn)
   await screen.findByText('Context strength: High')
   const industryChip = screen.getByText('Fintech')
   await userEvent.click(industryChip)

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -97,7 +97,6 @@ export default function AnalyzerCard({
     }
   })
   const [contextOpen, setContextOpen] = useState(false)
-  const [hasGenerated, setHasGenerated] = useState(false)
   const industryRef = useRef<HTMLInputElement>(null)
   const painRef = useRef<HTMLInputElement>(null)
   const stackRef = useRef<HTMLInputElement>(null)
@@ -189,7 +188,6 @@ export default function AnalyzerCard({
       })
       setInsightMarkdown((data.markdown ?? '').trim())
       setInsightMarkdownDegraded(data.degraded)
-      setHasGenerated(true)
     } catch (e) {
       setGenError((e as Error).message)
     } finally {
@@ -301,39 +299,45 @@ export default function AnalyzerCard({
         )}
         {cms && cms.length === 0 && (
           <>
-            {hasGenerated && (
-              <div className="mt-4">
-                <div className="flex flex-wrap gap-2">
-                  {industry && (
-                    <button
-                      className="border rounded-full px-2 py-0.5 text-xs"
-                      onClick={() => focusRef(industryRef)}
-                    >
-                      {industry}
-                    </button>
-                  )}
-                  {painPoint && (
-                    <button
-                      className="border rounded-full px-2 py-0.5 text-xs"
-                      onClick={() => focusRef(painRef)}
-                    >
-                      {painPoint}
-                    </button>
-                  )}
-                  {stackCount > 0 && (
-                    <button
-                      className="border rounded-full px-2 py-0.5 text-xs"
-                      onClick={() => focusRef(stackRef)}
-                    >
-                      {`Stack (${stackCount})`}
-                    </button>
-                  )}
-                </div>
-                <div className="text-xs text-gray-600 mt-1">
-                  Context strength: {contextStrength}
-                </div>
+            <div className="mt-4">
+              <div className="flex flex-wrap gap-2">
+                {industry && (
+                  <button
+                    className="border rounded-full px-2 py-0.5 text-xs"
+                    onClick={() => focusRef(industryRef)}
+                  >
+                    {industry}
+                  </button>
+                )}
+                {painPoint && (
+                  <button
+                    className="border rounded-full px-2 py-0.5 text-xs"
+                    onClick={() => focusRef(painRef)}
+                  >
+                    {painPoint}
+                  </button>
+                )}
+                {stackCount > 0 && (
+                  <button
+                    className="border rounded-full px-2 py-0.5 text-xs"
+                    onClick={() => focusRef(stackRef)}
+                  >
+                    {`Stack (${stackCount})`}
+                  </button>
+                )}
+                {!industry && !painPoint && stackCount === 0 && (
+                  <button
+                    className="border rounded-full px-2 py-0.5 text-xs"
+                    onClick={() => setContextOpen(true)}
+                  >
+                    Add context
+                  </button>
+                )}
               </div>
-            )}
+              <div className="text-xs text-gray-600 mt-1">
+                Context strength: {contextStrength}
+              </div>
+            </div>
             <button
               className="btn-primary mt-4"
               disabled={generating || insightLoading}


### PR DESCRIPTION
## Summary
- Show context chips and context strength before generating insights
- Provide "Add context" chip when no fields are set
- Update tests for new context chip behavior

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ea5b8ca948329a305b8088c67e2be