### PR TITLE
feat: add categorized martech selector

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -2,7 +2,7 @@
 
 ## POST /generate
 
-Optional field `martech_manual` (array of strings) allows overriding or supplementing detected vendors. Manual items appear first and duplicate entries from detected list are removed.
+Optional field `martech_manual` (array of objects with `category` and `vendor`) allows overriding or supplementing detected vendors. A legacy array of strings is still accepted for backward compatibility. Manual items appear first and duplicate entries from detected list are removed.
 
 ### Example
 
@@ -10,7 +10,9 @@ Optional field `martech_manual` (array of strings) allows overriding or suppleme
 {
   "url": "https://example.com",
   "martech": { "core": ["Google Analytics"] },
-  "martech_manual": ["Segment"],
+  "martech_manual": [
+    { "category": "analytics", "vendor": "Segment" }
+  ],
   "cms": ["WordPress"]
 }
 ```

--- a/interface/src/App.test.tsx
+++ b/interface/src/App.test.tsx
@@ -39,7 +39,7 @@ test('shows loading spinner and displays result', async () => {
     expect(document.querySelector('.animate-pulse')).toBeInTheDocument(),
   )
   await screen.findByText(/example\.com/i, undefined, { timeout: 2000 })
-  await screen.findByDisplayValue('GTM')
+  await screen.findByRole('tab', { name: /Content Management System/i })
 })
 
 test('shows error banner when request fails', async () => {

--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -79,7 +79,9 @@ test('renders result lists', async () => {
     />,
   )
   expect(screen.getByText('example.com')).toBeInTheDocument()
-  expect(screen.getByDisplayValue('GTM')).toBeInTheDocument()
+  expect(
+    screen.getByRole('tab', { name: /Content Management System/i })
+  ).toBeInTheDocument()
 })
 
 test('shows degraded banner', async () => {

--- a/interface/src/components/MartechCategorySelector.test.tsx
+++ b/interface/src/components/MartechCategorySelector.test.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MartechCategorySelector, { type MartechItem } from './MartechCategorySelector'
+
+test('select and deselect vendor', async () => {
+  const user = userEvent.setup()
+  const handle = vi.fn()
+  function Wrapper() {
+    const [val, setVal] = useState<MartechItem[]>([])
+    return (
+      <MartechCategorySelector
+        value={val}
+        onChange={(v) => {
+          setVal(v)
+          handle(v)
+        }}
+      />
+    )
+  }
+  render(<Wrapper />)
+  const analyticsTab = screen.getByRole('tab', { name: /Web \/ Product Analytics/i })
+  await user.click(analyticsTab)
+  const ga = screen.getByLabelText('Google Analytics') as HTMLInputElement
+  await user.click(ga)
+  expect(handle).toHaveBeenLastCalledWith([
+    { category: 'analytics', vendor: 'Google Analytics' },
+  ])
+  await user.click(ga)
+  expect(handle).toHaveBeenLastCalledWith([])
+})
+
+test('add vendor via other input', async () => {
+  const user = userEvent.setup()
+  const handle = vi.fn()
+  function Wrapper() {
+    const [val, setVal] = useState<MartechItem[]>([])
+    return (
+      <MartechCategorySelector
+        value={val}
+        onChange={(v) => {
+          setVal(v)
+          handle(v)
+        }}
+      />
+    )
+  }
+  render(<Wrapper />)
+  const input = screen.getByLabelText('cms-other')
+  await user.type(input, 'NewCMS{enter}')
+  expect(handle).toHaveBeenLastCalledWith([
+    { category: 'cms', vendor: 'NewCMS' },
+  ])
+})

--- a/interface/src/components/MartechCategorySelector.tsx
+++ b/interface/src/components/MartechCategorySelector.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+import catalogData from '../data/martech_catalog.json'
+
+export interface MartechItem {
+  category: string
+  vendor: string
+}
+
+interface Props {
+  value: MartechItem[]
+  onChange: (v: MartechItem[]) => void
+}
+
+const CATEGORIES = Object.entries(catalogData).filter(([key]) => key !== '_comment') as [string, { label: string; vendors: string[] }][]
+
+export default function MartechCategorySelector({ value, onChange }: Props) {
+  const [inputs, setInputs] = useState<Record<string, string>>({})
+
+  function isSelected(category: string, vendor: string) {
+    return value.some((v) => v.category === category && v.vendor === vendor)
+  }
+
+  function toggle(category: string, vendor: string, checked: boolean) {
+    const exists = isSelected(category, vendor)
+    if (checked && !exists) {
+      onChange([...value, { category, vendor }])
+    } else if (!checked && exists) {
+      onChange(value.filter((v) => !(v.category === category && v.vendor === vendor)))
+    }
+  }
+
+  function addOther(category: string) {
+    const v = (inputs[category] || '').trim()
+    if (!v) return
+    const current = CATEGORIES.find(([key]) => key === category)
+    if (current && !current[1].vendors.includes(v)) {
+      current[1].vendors.push(v)
+    }
+    setInputs((i) => ({ ...i, [category]: '' }))
+    toggle(category, v, true)
+  }
+
+  const [active, setActive] = useState(CATEGORIES[0][0])
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2 mb-2" role="tablist">
+        {CATEGORIES.map(([key, info]) => (
+          <button
+            key={key}
+            role="tab"
+            className={`px-2 py-1 rounded border ${active === key ? 'bg-gray-200' : ''}`}
+            onClick={() => setActive(key)}
+            aria-selected={active === key}
+          >
+            {info.label}
+          </button>
+        ))}
+      </div>
+      {CATEGORIES.map(([key, info]) => (
+        <div key={key} role="tabpanel" hidden={active !== key} className="mb-4">
+          <div className="flex flex-wrap gap-2">
+            {info.vendors.map((v) => (
+              <label key={v} className="border rounded px-2 py-1 text-sm flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={isSelected(key, v)}
+                  onChange={(e) => toggle(key, v, e.target.checked)}
+                />
+                {v}
+              </label>
+            ))}
+            <div className="flex items-center gap-1">
+              <input
+                aria-label={`${key}-other`}
+                value={inputs[key] || ''}
+                onChange={(e) => setInputs((i) => ({ ...i, [key]: e.target.value }))}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    addOther(key)
+                  }
+                }}
+                className="border rounded px-1 py-0.5 text-sm"
+                placeholder="Other..."
+              />
+              <button
+                type="button"
+                className="border rounded px-1 text-sm"
+                onClick={() => addOther(key)}
+              >
+                Add
+              </button>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/interface/src/components/index.ts
+++ b/interface/src/components/index.ts
@@ -14,5 +14,5 @@ export {
   default as InsightMarkdown,
   type InsightMarkdownProps,
 } from './InsightMarkdown'
-export { default as EditableMartechList } from './analysis/EditableMartechList'
+export { default as MartechCategorySelector } from './MartechCategorySelector'
 

--- a/interface/src/data/martech_catalog.json
+++ b/interface/src/data/martech_catalog.json
@@ -1,0 +1,77 @@
+{
+  "_comment": "Vendor lists sourced from W3Techs and Gartner/G2 alternatives pages [1-4]",
+  "cms": {
+    "label": "Content Management System",
+    "vendors": [
+      "WordPress",
+      "Drupal",
+      "Sitecore",
+      "Tridion",
+      "Contentful",
+      "Adobe Experience Manager"
+    ]
+  },
+  "analytics": {
+    "label": "Web / Product Analytics",
+    "vendors": [
+      "Google Analytics",
+      "Adobe Analytics",
+      "Mixpanel",
+      "Amplitude",
+      "Heap",
+      "Piwik PRO"
+    ]
+  },
+  "targeting": {
+    "label": "Targeting / Personalisation",
+    "vendors": [
+      "Optimizely",
+      "Dynamic Yield",
+      "Adobe Target",
+      "VWO",
+      "Monetate"
+    ]
+  },
+  "dmp": {
+    "label": "Data Management Platform",
+    "vendors": [
+      "Lotame",
+      "Adobe Audience Manager",
+      "Oracle BlueKai",
+      "Salesforce Audience Studio",
+      "OnAudience"
+    ]
+  },
+  "marketing_automation": {
+    "label": "Marketing Automation / Email",
+    "vendors": [
+      "HubSpot",
+      "Marketo",
+      "Pardot",
+      "ActiveCampaign",
+      "Mailchimp",
+      "Eloqua"
+    ]
+  },
+  "dsp": {
+    "label": "Demand-Side Platform",
+    "vendors": [
+      "Google DV360",
+      "The Trade Desk",
+      "Amazon DSP",
+      "MediaMath",
+      "Xandr",
+      "Yahoo DSP"
+    ]
+  },
+  "tag_management": {
+    "label": "Tag Management",
+    "vendors": [
+      "Google Tag Manager",
+      "Tealium",
+      "Adobe Launch",
+      "Ensighten",
+      "Segment"
+    ]
+  }
+}

--- a/interface/src/utils/requestSchema.ts
+++ b/interface/src/utils/requestSchema.ts
@@ -9,7 +9,11 @@ export const requestSchema = z.object({
     competitors: z.array(z.string()),
   }),
   cms: z.array(z.string()),
-  martech_manual: z.array(z.string()).optional(),
+  martech_manual: z
+    .array(
+      z.object({ category: z.string(), vendor: z.string() })
+    )
+    .optional(),
   industry: z.string().max(1024).optional(),
   pain_point: z.string().max(1024).optional(),
   evidence_standards: z.string().max(1024),

--- a/interface/tsconfig.app.json
+++ b/interface/tsconfig.app.json
@@ -9,6 +9,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- add static catalog of martech vendors grouped by category
- build tabbed MartechCategorySelector with checkbox vendors and "Other" input
- accept structured martech_manual items in gateway and merge with detected vendors

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test -- --run`
- `make lint` *(fails: flake8, mypy issues in repo)*
- `ruff check .`
- `black --check services/gateway/app.py tests/test_gateway.py` *(fails: would reformat)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eea20965c8329a0c23809214a8aa5