### PR TITLE
feat: add JIT domain scope controls

### DIFF
--- a/interface/.env.example
+++ b/interface/.env.example
@@ -1,3 +1,4 @@
 VITE_API_BASE_URL=http://localhost:8080
 # Optional: override gateway wait time for insight calls (seconds)
 INSIGHT_TIMEOUT=30
+VITE_USE_JIT_DOMAINS=false

--- a/interface/README.md
+++ b/interface/README.md
@@ -20,6 +20,8 @@ npm run dev
 
 Open `http://localhost:5173` in your browser and start analyzing URLs.
 
+Set `VITE_USE_JIT_DOMAINS=true` to enable the just-in-time domain scope controls.
+
 The analyzer form includes a **Technology Stack** picker, an **Industry**
 dropdown, and a **Pain Point** text box for additional context. Generated
 insights can be downloaded via the **Export Markdown** button.

--- a/interface/package.json
+++ b/interface/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build --outDir build",
     "lint": "eslint .",
+    "type-check": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
     "start": "serve -s build -l \"${PORT:-8000}\""

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -3,6 +3,7 @@ import { useFadeInOnView, useScrollPosition } from './hooks'
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 import { apiFetch, BASE_URL } from './api'
 import { normalizeUrl } from './utils'
+import ScopeChip from './components/domain/ScopeChip'
 import {
   AnalyzerCard,
   FeatureGrid,
@@ -87,6 +88,9 @@ export default function App() {
       <header className="sticky top-0 z-[1000] bg-white p-4 md:px-8 flex items-center justify-between">
         <div className="font-bold text-xl">Unitron</div>
         <nav className="hidden md:flex items-center text-sm">
+          {import.meta.env.VITE_USE_JIT_DOMAINS === 'true' && (
+            <ScopeChip />
+          )}
           <a href="#home" className="mx-3 font-semibold text-dark hover:text-accent">Home</a>
           <a href="/docs" className="mx-3 font-semibold text-dark hover:text-accent">Docs</a>
           <a href="https://github.com" className="mx-3 font-semibold text-dark hover:text-accent" target="_blank" rel="noreferrer">GitHub</a>

--- a/interface/src/components/PropertyResults.tsx
+++ b/interface/src/components/PropertyResults.tsx
@@ -31,10 +31,12 @@ function renderList(items: string[]) {
 export default function PropertyResults({ property }: { property: Property }) {
   return (
     <>
-      <div className="bg-gray-50 p-4 rounded mb-4">
-        <h3 className="font-medium">Domains</h3>
-        {renderList(property.domains)}
-      </div>
+      {import.meta.env.VITE_USE_JIT_DOMAINS !== 'true' && (
+        <div className="bg-gray-50 p-4 rounded mb-4">
+          <h3 className="font-medium">Domains</h3>
+          {renderList(property.domains)}
+        </div>
+      )}
       <div className="bg-gray-50 p-4 rounded mb-4">
         <h3 className="font-medium">Confidence</h3>
         <p>{Math.round(property.confidence * 100)}%</p>

--- a/interface/src/components/domain/DomainDrawer.stories.tsx
+++ b/interface/src/components/domain/DomainDrawer.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import DomainDrawer from './DomainDrawer'
+import { DomainProvider } from '../../contexts/DomainContext'
+
+const meta: Meta<typeof DomainDrawer> = {
+  component: DomainDrawer,
+}
+export default meta
+
+type Story = StoryObj<typeof DomainDrawer>
+
+export const Open: Story = {
+  render: () => (
+    <DomainProvider initial={['example.com','foo.com']}>
+      <DomainDrawer onClose={() => {}} />
+    </DomainProvider>
+  ),
+}

--- a/interface/src/components/domain/DomainDrawer.test.tsx
+++ b/interface/src/components/domain/DomainDrawer.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DomainDrawer from './DomainDrawer'
+import { DomainProvider, useDomains } from '../../contexts/DomainContext'
+
+function Wrapper() {
+  const { domains } = useDomains()
+  return (
+    <div>
+      <div data-testid="count">{domains.length}</div>
+      <DomainDrawer onClose={() => {}} />
+    </div>
+  )
+}
+
+test('save rerun updates domains and tracks', async () => {
+  const user = userEvent.setup()
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+  render(
+    <DomainProvider initial={['a.com']}>
+      <Wrapper />
+    </DomainProvider>,
+  )
+  const textarea = screen.getByRole('textbox')
+  await user.clear(textarea)
+  await user.type(textarea, 'b.com')
+  await user.click(screen.getByRole('button', { name: /save/i }))
+  expect(screen.getByTestId('count')).toHaveTextContent('1')
+  expect(log).toHaveBeenCalledWith('track', 'analysis_rerun', undefined)
+  log.mockRestore()
+})

--- a/interface/src/components/domain/DomainDrawer.tsx
+++ b/interface/src/components/domain/DomainDrawer.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useDomains } from '../../contexts/DomainContext'
+import { track } from '../../utils/analytics'
+
+export default function DomainDrawer({ onClose }: { onClose: () => void }) {
+  const { domains, setDomains } = useDomains()
+  const [text, setText] = useState(domains.join('\n'))
+
+  function save() {
+    const list = text
+      .split(/\n+/)
+      .map((d) => d.trim())
+      .filter(Boolean)
+    setDomains(list)
+    track('analysis_rerun')
+    onClose()
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black/50 flex justify-end" role="dialog">
+      <div className="bg-white w-[400px] p-4 h-full overflow-y-auto">
+        <h2 className="font-medium mb-2">Domain Scope</h2>
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="border w-full h-64 mb-2"
+        />
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose} className="px-3 py-1 border rounded">
+            Cancel
+          </button>
+          <button onClick={save} className="px-3 py-1 border rounded bg-blue-600 text-white">
+            Save & Rerun
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/interface/src/components/domain/DomainPopover.stories.tsx
+++ b/interface/src/components/domain/DomainPopover.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import DomainPopover from './DomainPopover'
+import ScopeChip from './ScopeChip'
+import { DomainProvider } from '../../contexts/DomainContext'
+
+const meta: Meta<typeof DomainPopover> = {
+  component: DomainPopover,
+}
+export default meta
+
+type Story = StoryObj<typeof DomainPopover>
+
+export const WithChip: Story = {
+  render: () => (
+    <DomainProvider initial={['example.com','test.com']}>
+      <ScopeChip />
+    </DomainProvider>
+  ),
+}

--- a/interface/src/components/domain/DomainPopover.tsx
+++ b/interface/src/components/domain/DomainPopover.tsx
@@ -1,0 +1,99 @@
+import { useState, useRef, useEffect, lazy, Suspense } from 'react'
+import { createPortal } from 'react-dom'
+import { useDomains } from '../../contexts/DomainContext'
+import { track } from '../../utils/analytics'
+
+const DomainDrawer = lazy(() => import('./DomainDrawer'))
+
+export default function DomainPopover({ onClose }: { onClose: () => void }) {
+  const { domains, addDomain, removeDomain } = useDomains()
+  const [input, setInput] = useState('')
+  const [drawer, setDrawer] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+      if (e.key.toLowerCase() === 'd') {
+        e.preventDefault()
+        setDrawer(true)
+        track('scope_open_drawer')
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  useEffect(() => {
+    function handle(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [onClose])
+
+  function handleAdd() {
+    if (input.trim()) {
+      addDomain(input.trim())
+      track('domain_add')
+      setInput('')
+    }
+  }
+
+  return (
+    <>
+      {createPortal(
+        <div
+          ref={ref}
+          className="absolute top-12 right-4 w-[280px] bg-white border p-4 rounded shadow"
+          role="dialog"
+        >
+          <ul className="mb-2">
+            {domains.slice(0, 5).map((d) => (
+              <li key={d} className="flex justify-between items-center">
+                <span>{d}</span>
+                <button
+                  aria-label="Remove"
+                  onClick={() => {
+                    removeDomain(d)
+                    track('domain_remove')
+                  }}
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="flex gap-2 mb-2">
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              className="border flex-1 px-1"
+              placeholder="Add domain"
+            />
+            <button onClick={handleAdd} className="px-2 border rounded">
+              Add
+            </button>
+          </div>
+          <button
+            className="underline text-sm"
+            onClick={() => {
+              setDrawer(true)
+              track('scope_open_drawer')
+            }}
+          >
+            Open Drawer
+          </button>
+        </div>,
+        document.body,
+      )}
+      {drawer && (
+        <Suspense fallback={null}>
+          <DomainDrawer onClose={() => setDrawer(false)} />
+        </Suspense>
+      )}
+    </>
+  )
+}

--- a/interface/src/components/domain/ScopeChip.stories.tsx
+++ b/interface/src/components/domain/ScopeChip.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import ScopeChip from './ScopeChip'
+import { DomainProvider } from '../../contexts/DomainContext'
+
+const meta: Meta<typeof ScopeChip> = {
+  component: ScopeChip,
+}
+export default meta
+
+type Story = StoryObj<typeof ScopeChip>
+
+export const Empty: Story = {
+  decorators: [(Story) => (<DomainProvider><Story /></DomainProvider>)],
+}
+
+export const Populated: Story = {
+  decorators: [
+    (Story) => (
+      <DomainProvider initial={['example.com', 'test.com']}>
+        <Story />
+      </DomainProvider>
+    ),
+  ],
+}

--- a/interface/src/components/domain/ScopeChip.test.tsx
+++ b/interface/src/components/domain/ScopeChip.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ScopeChip from './ScopeChip'
+import { DomainProvider, useDomains } from '../../contexts/DomainContext'
+
+function Wrapper() {
+  const { addDomain } = useDomains()
+  return (
+    <div>
+      <button onClick={() => addDomain('x.com')}>add</button>
+      <ScopeChip />
+    </div>
+  )
+}
+
+test('updates count and toggles popover', async () => {
+  const user = userEvent.setup()
+  render(
+    <DomainProvider>
+      <Wrapper />
+    </DomainProvider>,
+  )
+  const chip = screen.getByRole('button', { name: /Domains/ })
+  expect(chip).toHaveTextContent('0 Domains')
+  await user.click(screen.getByText('add'))
+  expect(chip).toHaveTextContent('1 Domains')
+  await user.click(chip)
+  expect(await screen.findByRole('dialog')).toBeInTheDocument()
+})

--- a/interface/src/components/domain/ScopeChip.tsx
+++ b/interface/src/components/domain/ScopeChip.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect, lazy, Suspense } from 'react'
+import { useDomains } from '../../contexts/DomainContext'
+import { track } from '../../utils/analytics'
+
+const DomainPopover = lazy(() => import('./DomainPopover'))
+
+export default function ScopeChip() {
+  const { domains } = useDomains()
+  const [open, setOpen] = useState(false)
+
+  function toggle() {
+    setOpen((o) => !o)
+    if (!open) track('scope_open_popover')
+  }
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.metaKey && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        toggle()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  })
+
+  return (
+    <>
+      <button
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={toggle}
+        className="px-2 py-1 border rounded mx-3"
+      >
+        {domains.length} Domains ▾
+      </button>
+      {open && (
+        <Suspense fallback={null}>
+          <DomainPopover onClose={() => setOpen(false)} />
+        </Suspense>
+      )}
+    </>
+  )
+}

--- a/interface/src/contexts/DomainContext.test.tsx
+++ b/interface/src/contexts/DomainContext.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook, act } from '@testing-library/react'
+import { DomainProvider, useDomains } from './DomainContext'
+
+function setup() {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DomainProvider>{children}</DomainProvider>
+  )
+  return renderHook(() => useDomains(), { wrapper })
+}
+
+test('crud operations', () => {
+  const { result } = setup()
+  act(() => result.current.addDomain('a.com'))
+  expect(result.current.domains).toEqual(['a.com'])
+  act(() => result.current.addDomain('b.com'))
+  expect(result.current.domains).toEqual(['a.com', 'b.com'])
+  act(() => result.current.removeDomain('a.com'))
+  expect(result.current.domains).toEqual(['b.com'])
+  act(() => result.current.setDomains(['c.com']))
+  expect(result.current.domains).toEqual(['c.com'])
+})

--- a/interface/src/contexts/DomainContext.tsx
+++ b/interface/src/contexts/DomainContext.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState } from 'react'
+import type { ReactNode } from 'react'
+
+export type DomainContextType = {
+  domains: string[]
+  setDomains: (d: string[]) => void
+  addDomain: (d: string) => void
+  removeDomain: (d: string) => void
+}
+
+const DomainContext = createContext<DomainContextType | undefined>(undefined)
+
+export function DomainProvider({
+  children,
+  initial = [],
+}: {
+  children: ReactNode
+  initial?: string[]
+}) {
+  const [domains, setDomains] = useState<string[]>(initial)
+
+  function addDomain(d: string) {
+    setDomains((prev) => (prev.includes(d) ? prev : [...prev, d]))
+  }
+
+  function removeDomain(d: string) {
+    setDomains((prev) => prev.filter((x) => x !== d))
+  }
+
+  return (
+    <DomainContext.Provider value={{ domains, setDomains, addDomain, removeDomain }}>
+      {children}
+    </DomainContext.Provider>
+  )
+}
+
+export function useDomains() {
+  const ctx = useContext(DomainContext)
+  if (!ctx) throw new Error('useDomains must be used within DomainProvider')
+  return ctx
+}

--- a/interface/src/main.tsx
+++ b/interface/src/main.tsx
@@ -9,11 +9,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { ErrorBoundary } from './components'
+import { DomainProvider } from './contexts/DomainContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ErrorBoundary>
-      <App />
-    </ErrorBoundary>
+    <DomainProvider>
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    </DomainProvider>
   </StrictMode>,
 )

--- a/interface/src/utils/analytics.ts
+++ b/interface/src/utils/analytics.ts
@@ -1,0 +1,12 @@
+export type AnalyticsEvent =
+  | 'scope_open_popover'
+  | 'scope_open_drawer'
+  | 'domain_add'
+  | 'domain_remove'
+  | 'analysis_rerun'
+
+export function track(event: AnalyticsEvent, payload?: Record<string, unknown>) {
+  // In production this would send to analytics backend.
+  // For now we log to console so tests can assert calls.
+  console.log('track', event, payload)
+}


### PR DESCRIPTION
## Summary
- add global `DomainContext` for managing domain scope
- introduce ScopeChip, Popover, and Drawer components with analytics tracking
- document `VITE_USE_JIT_DOMAINS` flag and hide legacy domain list when enabled

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat several existing files)*
- `pytest -q`
- `cd interface && npm test -- --run`
- `cd interface && npm run lint`
- `cd interface && npm run type-check`
- `cd interface && VITE_USE_JIT_DOMAINS=true npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f89f825088329b0f46f5331820055