### PR TITLE
fix: enable JIT domain scope via flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+        language_version: python3

--- a/app.py
+++ b/app.py
@@ -8,4 +8,3 @@ if svc not in _ALLOWED:
     raise RuntimeError(f"Unknown service: {svc}")
 module = importlib.import_module(f"services.{svc}.app")
 app = module.app
-

--- a/docs/lifespan-snippet.py
+++ b/docs/lifespan-snippet.py
@@ -2,6 +2,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 import httpx
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Create one shared ``httpx.AsyncClient``."""
@@ -10,4 +11,3 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         await app.state.client.aclose()
-

--- a/interface/.env.example
+++ b/interface/.env.example
@@ -1,3 +1,4 @@
 VITE_API_BASE_URL=http://localhost:8080
 # Optional: override gateway wait time for insight calls (seconds)
 INSIGHT_TIMEOUT=30
+VITE_USE_JIT_DOMAINS=false

--- a/interface/README.md
+++ b/interface/README.md
@@ -20,6 +20,8 @@ npm run dev
 
 Open `http://localhost:5173` in your browser and start analyzing URLs.
 
+Set `VITE_USE_JIT_DOMAINS=true` to enable the just-in-time domain scope controls.
+
 The analyzer form includes a **Technology Stack** picker, an **Industry**
 dropdown, and a **Pain Point** text box for additional context. Generated
 insights can be downloaded via the **Export Markdown** button.

--- a/interface/package.json
+++ b/interface/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build --outDir build",
     "lint": "eslint .",
+    "type-check": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
     "start": "serve -s build -l \"${PORT:-8000}\""

--- a/interface/src/App.flag.test.tsx
+++ b/interface/src/App.flag.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { DomainProvider } from './contexts/DomainContext'
+import { vi } from 'vitest'
+
+// dynamic import inside test to apply env flag before module evaluation
+
+test('renders scope chip when flag enabled', async () => {
+  const old = import.meta.env.VITE_USE_JIT_DOMAINS
+  import.meta.env.VITE_USE_JIT_DOMAINS = 'true'
+  global.IntersectionObserver = vi.fn(() => ({
+    observe: vi.fn(),
+    disconnect: vi.fn(),
+  })) as unknown as typeof IntersectionObserver
+  const { default: App } = await import('./App')
+  render(
+    <DomainProvider>
+      <App />
+    </DomainProvider>,
+  )
+  await screen.findByRole('button', { name: /Domains/ })
+  import.meta.env.VITE_USE_JIT_DOMAINS = old
+})

--- a/interface/src/App.test.tsx
+++ b/interface/src/App.test.tsx
@@ -4,6 +4,7 @@ import { vi, test, expect, beforeEach } from 'vitest'
 import { server } from './setupTests'
 import { http } from 'msw'
 import App from './App'
+import { DomainProvider } from './contexts/DomainContext'
 import { type AnalyzeResult } from './components'
 
 beforeEach(() => {
@@ -26,12 +27,16 @@ test('shows loading spinner and displays result', async () => {
   server.use(
     http.post('/analyze', async ({ request }) => {
       const body = await request.json()
-      expect(body).toEqual({ url: 'https://example.com', headless: false, force: false })
+      expect(body).toEqual({ url: 'https://example.com', headless: false, force: false, domains: [] })
       await new Promise((r) => setTimeout(r, 1000))
       return Response.json(full)
     })
   )
-  render(<App />)
+  render(
+    <DomainProvider>
+      <App />
+    </DomainProvider>,
+  )
   const input = screen.getByPlaceholderText('https://example.com')
   await userEvent.type(input, 'example.com')
   await userEvent.click(screen.getByRole('button', { name: /analyze/i }))
@@ -46,11 +51,15 @@ test('shows error banner when request fails', async () => {
   server.use(
     http.post('/analyze', async ({ request }) => {
       const body = await request.json()
-      expect(body).toEqual({ url: 'https://example.com', headless: false, force: false })
+      expect(body).toEqual({ url: 'https://example.com', headless: false, force: false, domains: [] })
       return new Response(null, { status: 500 })
     })
   )
-  render(<App />)
+  render(
+    <DomainProvider>
+      <App />
+    </DomainProvider>,
+  )
   const input = screen.getByPlaceholderText('https://example.com')
   await userEvent.type(input, 'example.com')
   await userEvent.click(screen.getByRole('button', { name: /analyze/i }))
@@ -75,11 +84,15 @@ test('shows degraded banner when martech is null', async () => {
   server.use(
     http.post('/analyze', async ({ request }) => {
       const body = await request.json()
-      expect(body).toEqual({ url: 'https://partial.com', headless: false, force: false })
+      expect(body).toEqual({ url: 'https://partial.com', headless: false, force: false, domains: [] })
       return Response.json(partial)
     })
   )
-  render(<App />)
+  render(
+    <DomainProvider>
+      <App />
+    </DomainProvider>,
+  )
   const input = screen.getByPlaceholderText('https://example.com')
   await userEvent.type(input, 'partial.com')
   await userEvent.click(screen.getByRole('button', { name: /analyze/i }))

--- a/interface/src/App.tsx
+++ b/interface/src/App.tsx
@@ -3,6 +3,9 @@ import { useFadeInOnView, useScrollPosition } from './hooks'
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 import { apiFetch, BASE_URL } from './api'
 import { normalizeUrl } from './utils'
+import ScopeChip from './components/domain/ScopeChip'
+import { USE_JIT_DOMAINS } from './config'
+import { useDomains } from './contexts/DomainContext'
 import {
   AnalyzerCard,
   FeatureGrid,
@@ -26,6 +29,7 @@ export default function App() {
   const [headless, setHeadless] = useState(false)
   const [force, setForce] = useState(false)
   const { showTop } = useScrollPosition()
+  const { domains } = useDomains()
   useFadeInOnView()
 
   async function checkHealth() {
@@ -59,7 +63,7 @@ export default function App() {
       const data = await apiFetch<AnalyzeResult>('/analyze', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: clean, headless, force }),
+        body: JSON.stringify({ url: clean, headless, force, domains }),
       })
       setResult(data)
     } catch (err) {
@@ -85,7 +89,10 @@ export default function App() {
         </div>
       )}
       <header className="sticky top-0 z-[1000] bg-white p-4 md:px-8 flex items-center justify-between">
-        <div className="font-bold text-xl">Unitron</div>
+        <div className="flex items-center gap-4">
+          <div className="font-bold text-xl">Unitron</div>
+          {USE_JIT_DOMAINS && <ScopeChip onRerun={onAnalyze} />}
+        </div>
         <nav className="hidden md:flex items-center text-sm">
           <a href="#home" className="mx-3 font-semibold text-dark hover:text-accent">Home</a>
           <a href="/docs" className="mx-3 font-semibold text-dark hover:text-accent">Docs</a>

--- a/interface/src/components/PropertyResults.tsx
+++ b/interface/src/components/PropertyResults.tsx
@@ -28,13 +28,17 @@ function renderList(items: string[]) {
   )
 }
 
+import { USE_JIT_DOMAINS } from '../config'
+
 export default function PropertyResults({ property }: { property: Property }) {
   return (
     <>
-      <div className="bg-gray-50 p-4 rounded mb-4">
-        <h3 className="font-medium">Domains</h3>
-        {renderList(property.domains)}
-      </div>
+      {!USE_JIT_DOMAINS && (
+        <div className="bg-gray-50 p-4 rounded mb-4">
+          <h3 className="font-medium">Domains</h3>
+          {renderList(property.domains)}
+        </div>
+      )}
       <div className="bg-gray-50 p-4 rounded mb-4">
         <h3 className="font-medium">Confidence</h3>
         <p>{Math.round(property.confidence * 100)}%</p>

--- a/interface/src/components/domain/DomainDrawer.stories.tsx
+++ b/interface/src/components/domain/DomainDrawer.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import DomainDrawer from './DomainDrawer'
+import { DomainProvider } from '../../contexts/DomainContext'
+
+const meta: Meta<typeof DomainDrawer> = {
+  component: DomainDrawer,
+}
+export default meta
+
+type Story = StoryObj<typeof DomainDrawer>
+
+export const Open: Story = {
+  render: () => (
+    <DomainProvider initial={['example.com', 'foo.com']}>
+      <DomainDrawer onClose={() => {}} onRerun={() => {}} />
+    </DomainProvider>
+  ),
+}

--- a/interface/src/components/domain/DomainDrawer.test.tsx
+++ b/interface/src/components/domain/DomainDrawer.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DomainDrawer from './DomainDrawer'
+import { DomainProvider, useDomains } from '../../contexts/DomainContext'
+
+function Wrapper({ rerun }: { rerun: () => void }) {
+  const { domains } = useDomains()
+  return (
+    <div>
+      <div data-testid="count">{domains.length}</div>
+      <DomainDrawer onClose={() => {}} onRerun={rerun} />
+    </div>
+  )
+}
+
+test('save rerun updates domains, tracks, and calls rerun', async () => {
+  const user = userEvent.setup()
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+  const rerun = vi.fn()
+  render(
+    <DomainProvider initial={['a.com']}>
+      <Wrapper rerun={rerun} />
+    </DomainProvider>,
+  )
+  const textarea = screen.getByRole('textbox')
+  await user.clear(textarea)
+  await user.type(textarea, 'b.com')
+  await user.click(screen.getByRole('button', { name: /save/i }))
+  expect(screen.getByTestId('count')).toHaveTextContent('1')
+  expect(log).toHaveBeenCalledWith('track', 'analysis_rerun', undefined)
+  expect(rerun).toHaveBeenCalled()
+  log.mockRestore()
+})

--- a/interface/src/components/domain/DomainDrawer.tsx
+++ b/interface/src/components/domain/DomainDrawer.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useDomains } from '../../contexts/DomainContext'
+import { track } from '../../utils/analytics'
+
+export default function DomainDrawer({
+  onClose,
+  onRerun,
+}: {
+  onClose: () => void
+  onRerun: () => void
+}) {
+  const { domains, setDomains } = useDomains()
+  const [text, setText] = useState(domains.join('\n'))
+
+  function save() {
+    const list = text
+      .split(/\n+/)
+      .map((d) => d.trim())
+      .filter(Boolean)
+    setDomains(list)
+    track('analysis_rerun')
+    onRerun()
+    onClose()
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black/50 flex justify-end" role="dialog">
+      <div className="bg-white w-[400px] p-4 h-full overflow-y-auto">
+        <h2 className="font-medium mb-2">Domain Scope</h2>
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="border w-full h-64 mb-2"
+        />
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose} className="px-3 py-1 border rounded">
+            Cancel
+          </button>
+          <button onClick={save} className="px-3 py-1 border rounded bg-blue-600 text-white">
+            Save & Rerun
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/interface/src/components/domain/DomainPopover.stories.tsx
+++ b/interface/src/components/domain/DomainPopover.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import DomainPopover from './DomainPopover'
+import ScopeChip from './ScopeChip'
+import { DomainProvider } from '../../contexts/DomainContext'
+
+const meta: Meta<typeof DomainPopover> = {
+  component: DomainPopover,
+}
+export default meta
+
+type Story = StoryObj<typeof DomainPopover>
+
+export const WithChip: Story = {
+  render: () => (
+    <DomainProvider initial={['example.com', 'test.com']}>
+      <ScopeChip onRerun={() => {}} />
+    </DomainProvider>
+  ),
+}

--- a/interface/src/components/domain/DomainPopover.tsx
+++ b/interface/src/components/domain/DomainPopover.tsx
@@ -1,0 +1,105 @@
+import { useState, useRef, useEffect, lazy, Suspense } from 'react'
+import { createPortal } from 'react-dom'
+import { useDomains } from '../../contexts/DomainContext'
+import { track } from '../../utils/analytics'
+
+const DomainDrawer = lazy(() => import('./DomainDrawer'))
+
+export default function DomainPopover({
+  onClose,
+  onRerun,
+}: {
+  onClose: () => void
+  onRerun: () => void
+}) {
+  const { domains, addDomain, removeDomain } = useDomains()
+  const [input, setInput] = useState('')
+  const [drawer, setDrawer] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+      if (e.key.toLowerCase() === 'd') {
+        e.preventDefault()
+        setDrawer(true)
+        track('scope_open_drawer')
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  useEffect(() => {
+    function handle(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [onClose])
+
+  function handleAdd() {
+    if (input.trim()) {
+      addDomain(input.trim())
+      track('domain_add')
+      setInput('')
+    }
+  }
+
+  return (
+    <>
+      {createPortal(
+        <div
+          ref={ref}
+          className="absolute top-12 right-4 w-[280px] bg-white border p-4 rounded shadow"
+          role="dialog"
+        >
+          <ul className="mb-2">
+            {domains.slice(0, 5).map((d) => (
+              <li key={d} className="flex justify-between items-center">
+                <span>{d}</span>
+                <button
+                  aria-label="Remove"
+                  onClick={() => {
+                    removeDomain(d)
+                    track('domain_remove')
+                  }}
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="flex gap-2 mb-2">
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              className="border flex-1 px-1"
+              placeholder="Add domain"
+            />
+            <button onClick={handleAdd} className="px-2 border rounded">
+              Add
+            </button>
+          </div>
+          <button
+            className="underline text-sm"
+            onClick={() => {
+              setDrawer(true)
+              track('scope_open_drawer')
+            }}
+          >
+            Open Drawer
+          </button>
+        </div>,
+        document.body,
+      )}
+      {drawer && (
+        <Suspense fallback={null}>
+          <DomainDrawer onClose={() => setDrawer(false)} onRerun={onRerun} />
+        </Suspense>
+      )}
+    </>
+  )
+}

--- a/interface/src/components/domain/ScopeChip.stories.tsx
+++ b/interface/src/components/domain/ScopeChip.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import ScopeChip from './ScopeChip'
+import { DomainProvider } from '../../contexts/DomainContext'
+
+const meta: Meta<typeof ScopeChip> = {
+  component: ScopeChip,
+  args: { onRerun: () => {} },
+}
+export default meta
+
+type Story = StoryObj<typeof ScopeChip>
+
+export const Empty: Story = {
+  decorators: [(Story) => (<DomainProvider><Story /></DomainProvider>)],
+}
+
+export const Populated: Story = {
+  decorators: [
+    (Story) => (
+      <DomainProvider initial={['example.com', 'test.com']}>
+        <Story />
+      </DomainProvider>
+    ),
+  ],
+}

--- a/interface/src/components/domain/ScopeChip.test.tsx
+++ b/interface/src/components/domain/ScopeChip.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ScopeChip from './ScopeChip'
+import { DomainProvider, useDomains } from '../../contexts/DomainContext'
+
+function Wrapper() {
+  const { addDomain } = useDomains()
+  return (
+    <div>
+      <button onClick={() => addDomain('x.com')}>add</button>
+      <ScopeChip onRerun={() => {}} />
+    </div>
+  )
+}
+
+test('updates count and toggles popover', async () => {
+  const user = userEvent.setup()
+  render(
+    <DomainProvider>
+      <Wrapper />
+    </DomainProvider>,
+  )
+  const chip = screen.getByRole('button', { name: /Domains/ })
+  expect(chip).toHaveTextContent('0 Domains')
+  await user.click(screen.getByText('add'))
+  expect(chip).toHaveTextContent('1 Domains')
+  await user.click(chip)
+  expect(await screen.findByRole('dialog')).toBeInTheDocument()
+})

--- a/interface/src/components/domain/ScopeChip.tsx
+++ b/interface/src/components/domain/ScopeChip.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect, lazy, Suspense } from 'react'
+import { useDomains } from '../../contexts/DomainContext'
+import { track } from '../../utils/analytics'
+
+const DomainPopover = lazy(() => import('./DomainPopover'))
+
+export default function ScopeChip({ onRerun }: { onRerun: () => void }) {
+  const { domains } = useDomains()
+  const [open, setOpen] = useState(false)
+
+  function toggle() {
+    setOpen((o) => !o)
+    if (!open) track('scope_open_popover')
+  }
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.metaKey && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        toggle()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  })
+
+  return (
+    <>
+      <button
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={toggle}
+        className="px-2 py-1 border rounded mx-3"
+      >
+        {domains.length} Domains ▾
+      </button>
+      {open && (
+        <Suspense fallback={null}>
+          <DomainPopover onClose={() => setOpen(false)} onRerun={onRerun} />
+        </Suspense>
+      )}
+    </>
+  )
+}

--- a/interface/src/config.ts
+++ b/interface/src/config.ts
@@ -1,0 +1,2 @@
+export const USE_JIT_DOMAINS =
+  (import.meta.env.VITE_USE_JIT_DOMAINS ?? '').toLowerCase() === 'true'

--- a/interface/src/contexts/DomainContext.test.tsx
+++ b/interface/src/contexts/DomainContext.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook, act } from '@testing-library/react'
+import { DomainProvider, useDomains } from './DomainContext'
+
+function setup() {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DomainProvider>{children}</DomainProvider>
+  )
+  return renderHook(() => useDomains(), { wrapper })
+}
+
+test('crud operations', () => {
+  const { result } = setup()
+  act(() => result.current.addDomain('a.com'))
+  expect(result.current.domains).toEqual(['a.com'])
+  act(() => result.current.addDomain('b.com'))
+  expect(result.current.domains).toEqual(['a.com', 'b.com'])
+  act(() => result.current.removeDomain('a.com'))
+  expect(result.current.domains).toEqual(['b.com'])
+  act(() => result.current.setDomains(['c.com']))
+  expect(result.current.domains).toEqual(['c.com'])
+})

--- a/interface/src/contexts/DomainContext.tsx
+++ b/interface/src/contexts/DomainContext.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState } from 'react'
+import type { ReactNode } from 'react'
+
+export type DomainContextType = {
+  domains: string[]
+  setDomains: (d: string[]) => void
+  addDomain: (d: string) => void
+  removeDomain: (d: string) => void
+}
+
+const DomainContext = createContext<DomainContextType | undefined>(undefined)
+
+export function DomainProvider({
+  children,
+  initial = [],
+}: {
+  children: ReactNode
+  initial?: string[]
+}) {
+  const [domains, setDomains] = useState<string[]>(initial)
+
+  function addDomain(d: string) {
+    setDomains((prev) => (prev.includes(d) ? prev : [...prev, d]))
+  }
+
+  function removeDomain(d: string) {
+    setDomains((prev) => prev.filter((x) => x !== d))
+  }
+
+  return (
+    <DomainContext.Provider value={{ domains, setDomains, addDomain, removeDomain }}>
+      {children}
+    </DomainContext.Provider>
+  )
+}
+
+export function useDomains() {
+  const ctx = useContext(DomainContext)
+  if (!ctx) throw new Error('useDomains must be used within DomainProvider')
+  return ctx
+}

--- a/interface/src/main.tsx
+++ b/interface/src/main.tsx
@@ -9,11 +9,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { ErrorBoundary } from './components'
+import { DomainProvider } from './contexts/DomainContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ErrorBoundary>
-      <App />
-    </ErrorBoundary>
+    <DomainProvider>
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    </DomainProvider>
   </StrictMode>,
 )

--- a/interface/src/utils/analytics.ts
+++ b/interface/src/utils/analytics.ts
@@ -1,0 +1,12 @@
+export type AnalyticsEvent =
+  | 'scope_open_popover'
+  | 'scope_open_drawer'
+  | 'domain_add'
+  | 'domain_remove'
+  | 'analysis_rerun'
+
+export function track(event: AnalyticsEvent, payload?: Record<string, unknown>) {
+  // In production this would send to analytics backend.
+  // For now we log to console so tests can assert calls.
+  console.log('track', event, payload)
+}

--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -118,9 +118,7 @@ class GenerateRequest(BaseModel):
             "example": {
                 "url": "https://example.com",
                 "martech": {"core": ["Google Analytics"]},
-                "martech_manual": [
-                    {"category": "analytics", "vendor": "Segment"}
-                ],
+                "martech_manual": [{"category": "analytics", "vendor": "Segment"}],
                 "cms": ["WordPress"],
             }
         }

--- a/services/insight/app.py
+++ b/services/insight/app.py
@@ -125,6 +125,7 @@ class ReadyResponse(BaseModel):
 class ResearchRequest(BaseModel):
     topic: str
 
+
 class MarkdownResponse(BaseModel):
     markdown: str
     degraded: bool
@@ -475,7 +476,10 @@ async def insight_and_personas(req: InsightPersonaRequest) -> JSONResponse:
             insight_text = insight_raw
 
         personas_source: Any
-        if isinstance(personas_raw, dict) and "generated_buyer_personas" in personas_raw:
+        if (
+            isinstance(personas_raw, dict)
+            and "generated_buyer_personas" in personas_raw
+        ):
             personas_source = personas_raw["generated_buyer_personas"]
         else:
             personas_source = personas_raw
@@ -485,9 +489,9 @@ async def insight_and_personas(req: InsightPersonaRequest) -> JSONResponse:
 
             domain = urlparse(req.url).netloc or req.url
             tech_names = [item.get("vendor", "") for item in req.stack]
-            tech_text = ", ".join(
-                sorted({name for name in tech_names if name})
-            ) or "unknown"
+            tech_text = (
+                ", ".join(sorted({name for name in tech_names if name})) or "unknown"
+            )
             personas_list = [
                 {
                     "id": "company",

--- a/services/insight/orchestrator.py
+++ b/services/insight/orchestrator.py
@@ -72,7 +72,11 @@ async def call_openai_with_retry(
                 finish_reason = "stop"
                 events = await client.chat.completions.create(stream=True, **params)
                 async for event in events:
-                    delta = event.choices[0].delta.get("content") if hasattr(event.choices[0], "delta") else None
+                    delta = (
+                        event.choices[0].delta.get("content")
+                        if hasattr(event.choices[0], "delta")
+                        else None
+                    )
                     if delta:
                         content += delta
                     fr = getattr(event.choices[0], "finish_reason", None)
@@ -174,7 +178,10 @@ def build_prompt(
     tech_text = json.dumps(technology) if technology else ""
     industry_text = industry or ""
     pain_text = pain_point or ""
-    stack_lines = [f"  - {item.get('category', '')}: {item.get('vendor', '')}" for item in (stack or [])]
+    stack_lines = [
+        f"  - {item.get('category', '')}: {item.get('vendor', '')}"
+        for item in (stack or [])
+    ]
     context_text = "\n".join(
         [
             "Context",
@@ -200,4 +207,3 @@ def build_prompt(
     )
     prompt += MARKDOWN_OUTLINE
     return prompt
-

--- a/services/martech/app.py
+++ b/services/martech/app.py
@@ -75,9 +75,7 @@ except Exception:
     fingerprints = DEFAULT_FINGERPRINTS or {}
 
 try:
-    cms_fingerprints: dict[str, Any] | None = load_fingerprints(
-        CMS_FINGERPRINT_PATH
-    )
+    cms_fingerprints: dict[str, Any] | None = load_fingerprints(CMS_FINGERPRINT_PATH)
 except Exception:
     cms_fingerprints = DEFAULT_CMS_FINGERPRINTS or {}
 cache: dict[str, dict[str, Any]] = {}
@@ -164,9 +162,8 @@ async def _extract_scripts(
                     external.append(script_text)
                     if "googletagmanager.com/gtm.js" in src:
                         import re
-                        matches = re.findall(
-                            r"https?://[^\"']+\.js", script_text
-                        )
+
+                        matches = re.findall(r"https?://[^\"']+\.js", script_text)
                         urls.update(matches)
                 except Exception:
                     external.append("")

--- a/services/shared/fingerprint.py
+++ b/services/shared/fingerprint.py
@@ -207,8 +207,6 @@ except Exception:
     DEFAULT_FINGERPRINTS = {}
 
 try:
-    DEFAULT_CMS_FINGERPRINTS = load_fingerprints(
-        BASE_DIR / "cms_fingerprints.yaml"
-    )
+    DEFAULT_CMS_FINGERPRINTS = load_fingerprints(BASE_DIR / "cms_fingerprints.yaml")
 except Exception:
     DEFAULT_CMS_FINGERPRINTS = {}

--- a/services/shared/utils.py
+++ b/services/shared/utils.py
@@ -1,4 +1,3 @@
-
 from typing import Sequence
 from .fingerprint import (
     DEFAULT_FINGERPRINTS,
@@ -51,11 +50,7 @@ def detect_vendors(
         fingerprints = DEFAULT_FINGERPRINTS
 
     soup = BeautifulSoup(html, "html.parser")
-    srcs = [
-        tag.get("src") or ""
-        for tag in soup.find_all("script")
-        if tag.get("src")
-    ]
+    srcs = [tag.get("src") or "" for tag in soup.find_all("script") if tag.get("src")]
     if urls:
         srcs.extend(urls)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+
 # Skip the entire suite when optional heavy dependencies are missing.
 def _is_available(mod: str) -> bool:
     try:
@@ -14,7 +15,9 @@ def _is_available(mod: str) -> bool:
     except ModuleNotFoundError:
         return False
 
+
 MISSING = [mod for mod in ("playwright.async_api",) if not _is_available(mod)]
+
 
 def pytest_configure(config):
     if MISSING:

--- a/tests/test_credibility.py
+++ b/tests/test_credibility.py
@@ -30,9 +30,7 @@ def test_parse_and_score():
 
 
 def test_gap_flags():
-    rows = [
-        {"Source": "https://a.com", "Publisher": "Foo", "Date": "2020-01-01"}
-    ]
+    rows = [{"Source": "https://a.com", "Publisher": "Foo", "Date": "2020-01-01"}]
     scores = compute_scores(rows, today=datetime.date(2021, 1, 1))
     assert scores["recency"] == "[Data Gap]"
     assert scores["cross_agreement"] == "[Data Gap]"

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -445,9 +445,7 @@ def test_generate_merges_manual(monkeypatch):
         json={
             "url": "https://example.com",
             "martech": {"core": ["Google Analytics"]},
-            "martech_manual": [
-                {"category": "analytics", "vendor": "Segment"}
-            ],
+            "martech_manual": [{"category": "analytics", "vendor": "Segment"}],
             "cms": [],
         },
     )

--- a/tests/test_insight_retry.py
+++ b/tests/test_insight_retry.py
@@ -33,8 +33,30 @@ def test_retry_rate_limit(monkeypatch):
                 err.status_code = 429
                 raise err
             choice = resp.json()["choices"][0]
-            message = type("obj", (), {"content": choice["message"]["content"], "finish_reason": choice.get("finish_reason")})()
-            return type("obj", (), {"choices": [type("obj", (), {"message": message, "finish_reason": message.finish_reason})()]})
+            message = type(
+                "obj",
+                (),
+                {
+                    "content": choice["message"]["content"],
+                    "finish_reason": choice.get("finish_reason"),
+                },
+            )()
+            return type(
+                "obj",
+                (),
+                {
+                    "choices": [
+                        type(
+                            "obj",
+                            (),
+                            {
+                                "message": message,
+                                "finish_reason": message.finish_reason,
+                            },
+                        )()
+                    ]
+                },
+            )
 
     class DummyClient:
         def __init__(self, *a, **kw) -> None:

--- a/tests/test_martech_detection.py
+++ b/tests/test_martech_detection.py
@@ -46,8 +46,7 @@ def random_page():
 @pytest.fixture
 def ga_gtm_url():
     html = (
-        "<script src='https://www.googletagmanager.com/gtag/js?id=G-XYZ'>"
-        "</script>"
+        "<script src='https://www.googletagmanager.com/gtag/js?id=G-XYZ'>" "</script>"
     )
     return html, {}
 
@@ -97,9 +96,7 @@ def ga_id():
 
 @pytest.fixture
 def hotjar_window():
-    html = (
-        "<script>window.hotjar = window.hotjar || function(){};</script>"
-    )
+    html = "<script>window.hotjar = window.hotjar || function(){};</script>"
     return html, {}
 
 


### PR DESCRIPTION
## Summary
- gate JIT domain scope via `USE_JIT_DOMAINS` config and render ScopeChip when flag set
- wire Save & Rerun to re-trigger analysis with updated domain list
- add black pre-commit config and format repository

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `cd interface && npm test -- --run`
- `cd interface && npm run lint`
- `cd interface && npm run type-check`
- `cd interface && VITE_USE_JIT_DOMAINS=true npm run build`
- `docker compose --profile ui up --build -d` *(fails: command not found)*
- `curl -f http://localhost:5173` *(fails: couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_688f89f825088329b0f46f5331820055