### PR TITLE
feat(ui): gate legacy Domains list behind JIT flag

### DIFF
--- a/interface/src/App.flag.test.tsx
+++ b/interface/src/App.flag.test.tsx
@@ -17,6 +17,7 @@ test('renders scope chip when flag enabled', async () => {
       <App />
     </DomainProvider>,
   )
-  await screen.findByRole('button', { name: /Domains/ })
+  // multiple scope chips render in header/nav when flag enabled
+  expect(screen.getAllByRole('button', { name: /Domains/ }).length).toBeGreaterThan(0)
   import.meta.env.VITE_USE_JIT_DOMAINS = old
 })

--- a/interface/src/LegacyDomainsFlag.test.tsx
+++ b/interface/src/LegacyDomainsFlag.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+
+// dynamic import to respect env flag before evaluation
+
+test('hides legacy Domains heading when flag enabled', async () => {
+  const old = import.meta.env.VITE_USE_JIT_DOMAINS
+  import.meta.env.VITE_USE_JIT_DOMAINS = 'true'
+  const { default: PropertyResults } = await import('./components/PropertyResults')
+  render(
+    <PropertyResults
+      property={{ domains: ['unitron.ai'], confidence: 0.9, notes: ['footnote'] }}
+    />,
+  )
+  expect(screen.queryByRole('heading', { name: /Domains/i })).not.toBeInTheDocument()
+  import.meta.env.VITE_USE_JIT_DOMAINS = old
+})

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -10,6 +10,7 @@ import { apiFetch } from '../api'
 import { normalizeUrl } from '../utils'
 import { requestSchema } from '../utils/requestSchema'
 import { ORG_CONTEXT } from '../config/orgContext'
+import { USE_JIT_DOMAINS } from '../config'
 import Sheet from './ui/sheet'
 
 const vendorToCategory: Record<string, string> = {}
@@ -256,9 +257,16 @@ export default function AnalyzerCard({
                 <a href="#cms" className="underline text-blue-800 focus:outline-none focus:ring-2 ring-offset-2 ring-blue-500" tabIndex={0}>CMS</a>
               </li>
             )}
-            {property && property.notes.length > 0 && (
+            {!USE_JIT_DOMAINS && property && property.notes.length > 0 && (
               <li>
-                <a href="#footnotes" className="underline text-blue-800 focus:outline-none focus:ring-2 ring-offset-2 ring-blue-500" tabIndex={0}>Footnotes</a>
+                {/* TODO: delete legacy Footnotes link once JIT Domains fully launches */}
+                <a
+                  href="#footnotes"
+                  className="underline text-blue-800 focus:outline-none focus:ring-2 ring-offset-2 ring-blue-500"
+                  tabIndex={0}
+                >
+                  Footnotes
+                </a>
               </li>
             )}
           </ul>
@@ -313,12 +321,22 @@ export default function AnalyzerCard({
             <CmsResults cms={cms} />
           </section>
         )}
-        {property && property.notes.length > 0 && (
+        {!USE_JIT_DOMAINS && property && property.notes.length > 0 && (
           <section id="footnotes" className="bg-gray-50 p-4 rounded mt-4">
+            {/* TODO: delete legacy Footnotes once JIT Domains fully launches */}
             <h3 className="font-medium mb-2">Footnotes</h3>
             <ol className="list-decimal list-inside space-y-1">
               {property.notes.map((n, i) => (
-                <li key={i} id={`fn${i + 1}`}>{n} <a href={`#fnref${i + 1}`} className="underline text-blue-800 ml-1" tabIndex={0}>↩</a></li>
+                <li key={i} id={`fn${i + 1}`}>
+                  {n}{' '}
+                  <a
+                    href={`#fnref${i + 1}`}
+                    className="underline text-blue-800 ml-1"
+                    tabIndex={0}
+                  >
+                    ↩
+                  </a>
+                </li>
               ))}
             </ol>
           </section>

--- a/interface/src/components/PropertyResults.tsx
+++ b/interface/src/components/PropertyResults.tsx
@@ -34,18 +34,21 @@ export default function PropertyResults({ property }: { property: Property }) {
   return (
     <>
       {!USE_JIT_DOMAINS && (
-        <div className="bg-gray-50 p-4 rounded mb-4">
-          <h3 className="font-medium">Domains</h3>
-          {renderList(property.domains)}
-        </div>
+        <>
+          {/* TODO: delete legacy Domains/Notes once JIT Domains fully launches */}
+          <div className="bg-gray-50 p-4 rounded mb-4">
+            <h3 className="font-medium">Domains</h3>
+            {renderList(property.domains)}
+          </div>
+          <div className="bg-gray-50 p-4 rounded mb-4">
+            <h3 className="font-medium mb-2">Notes</h3>
+            {renderList(property.notes)}
+          </div>
+        </>
       )}
       <div className="bg-gray-50 p-4 rounded mb-4">
         <h3 className="font-medium">Confidence</h3>
         <p>{Math.round(property.confidence * 100)}%</p>
-      </div>
-      <div className="bg-gray-50 p-4 rounded mb-4">
-        <h3 className="font-medium mb-2">Notes</h3>
-        {renderList(property.notes)}
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
- hide legacy Domains/Notes block when `VITE_USE_JIT_DOMAINS` is true
- gate footnotes link and section behind the same flag
- add test confirming Domains heading disappears when flag is enabled

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`
- `cd interface && npm run lint`
- `cd interface && npm run type-check`
- `cd interface && npm test -- --run`
- `cd interface && VITE_USE_JIT_DOMAINS=true npm run build`
- `cd interface && VITE_USE_JIT_DOMAINS=false npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fa43148c0832987044831e0a4983b