### PR TITLE
feat(ui): remove legacy Domains/Notes/Footnotes block

### DIFF
--- a/interface/src/App.test.tsx
+++ b/interface/src/App.test.tsx
@@ -43,7 +43,7 @@ test('shows loading spinner and displays result', async () => {
   await waitFor(() =>
     expect(document.querySelector('.animate-pulse')).toBeInTheDocument(),
   )
-  await screen.findByText(/example\.com/i, undefined, { timeout: 2000 })
+  await screen.findByRole('heading', { name: 'Confidence' })
   await screen.findByRole('tab', { name: /Content Management System/i })
 })
 
@@ -96,6 +96,6 @@ test('shows degraded banner when martech is null', async () => {
   const input = screen.getByPlaceholderText('https://example.com')
   await userEvent.type(input, 'partial.com')
   await userEvent.click(screen.getByRole('button', { name: /analyze/i }))
-  await screen.findByText('partial.com')
+  await screen.findByRole('heading', { name: 'Confidence' })
   await screen.findByText(/partial results/i)
 })

--- a/interface/src/LegacyDomainsFlag.test.tsx
+++ b/interface/src/LegacyDomainsFlag.test.tsx
@@ -6,11 +6,7 @@ test('hides legacy Domains heading when flag enabled', async () => {
   const old = import.meta.env.VITE_USE_JIT_DOMAINS
   import.meta.env.VITE_USE_JIT_DOMAINS = 'true'
   const { default: PropertyResults } = await import('./components/PropertyResults')
-  render(
-    <PropertyResults
-      property={{ domains: ['unitron.ai'], confidence: 0.9, notes: ['footnote'] }}
-    />,
-  )
+  render(<PropertyResults property={{ confidence: 0.9 }} />)
   expect(screen.queryByRole('heading', { name: /Domains/i })).not.toBeInTheDocument()
   import.meta.env.VITE_USE_JIT_DOMAINS = old
 })

--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -78,7 +78,9 @@ test('renders result lists', async () => {
       result={result}
     />,
   )
-  expect(screen.getByText('example.com')).toBeInTheDocument()
+  expect(
+    screen.getByRole('heading', { name: 'Confidence' })
+  ).toBeInTheDocument()
   expect(
     screen.getByRole('tab', { name: /Content Management System/i })
   ).toBeInTheDocument()

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -10,7 +10,6 @@ import { apiFetch } from '../api'
 import { normalizeUrl } from '../utils'
 import { requestSchema } from '../utils/requestSchema'
 import { ORG_CONTEXT } from '../config/orgContext'
-import { USE_JIT_DOMAINS } from '../config'
 import Sheet from './ui/sheet'
 
 const vendorToCategory: Record<string, string> = {}
@@ -254,18 +253,12 @@ export default function AnalyzerCard({
             )}
             {cms != null && (
               <li>
-                <a href="#cms" className="underline text-blue-800 focus:outline-none focus:ring-2 ring-offset-2 ring-blue-500" tabIndex={0}>CMS</a>
-              </li>
-            )}
-            {!USE_JIT_DOMAINS && property && property.notes.length > 0 && (
-              <li>
-                {/* TODO: delete legacy Footnotes link once JIT Domains fully launches */}
                 <a
-                  href="#footnotes"
+                  href="#cms"
                   className="underline text-blue-800 focus:outline-none focus:ring-2 ring-offset-2 ring-blue-500"
                   tabIndex={0}
                 >
-                  Footnotes
+                  CMS
                 </a>
               </li>
             )}
@@ -319,26 +312,6 @@ export default function AnalyzerCard({
         {cms != null && (
           <section id="cms">
             <CmsResults cms={cms} />
-          </section>
-        )}
-        {!USE_JIT_DOMAINS && property && property.notes.length > 0 && (
-          <section id="footnotes" className="bg-gray-50 p-4 rounded mt-4">
-            {/* TODO: delete legacy Footnotes once JIT Domains fully launches */}
-            <h3 className="font-medium mb-2">Footnotes</h3>
-            <ol className="list-decimal list-inside space-y-1">
-              {property.notes.map((n, i) => (
-                <li key={i} id={`fn${i + 1}`}>
-                  {n}{' '}
-                  <a
-                    href={`#fnref${i + 1}`}
-                    className="underline text-blue-800 ml-1"
-                    tabIndex={0}
-                  >
-                    ↩
-                  </a>
-                </li>
-              ))}
-            </ol>
           </section>
         )}
         {cms && cms.length === 0 && (

--- a/interface/src/components/PropertyResults.test.tsx
+++ b/interface/src/components/PropertyResults.test.tsx
@@ -3,15 +3,13 @@ import { test } from 'vitest'
 import PropertyResults from './PropertyResults'
 
 const property = {
-  domains: ['example.com'],
   confidence: 0.8,
-  notes: ['note'],
 }
 
-test('renders property fields', () => {
+test('renders confidence only', () => {
   render(<PropertyResults property={property} />)
-  screen.getByText('example.com')
   screen.getByText('80%')
-  screen.getByText('note')
+  expect(screen.queryByText('example.com')).toBeNull()
+  expect(screen.queryByText('note')).toBeNull()
 })
 

--- a/interface/src/components/PropertyResults.tsx
+++ b/interface/src/components/PropertyResults.tsx
@@ -1,55 +1,12 @@
-export type Property = {
-  domains: string[]
-  confidence: number
-  notes: string[]
-}
-
-function renderList(items: string[]) {
-  if (!items || items.length === 0) {
-    return <p className="italic">Nothing detected</p>
-  }
+export default function PropertyResults({
+  property,
+}: {
+  property: { confidence: number }
+}) {
   return (
-    <ul className="list-disc list-inside space-y-1">
-      {items.map((i, idx) => (
-        <li key={i}>
-          {i}{' '}
-          <sup id={`fnref${idx + 1}`}>
-            <a
-              href={`#fn${idx + 1}`}
-              className="underline text-blue-800 focus:outline-none focus:ring-2 ring-offset-2 ring-blue-500"
-              tabIndex={0}
-            >
-              [{idx + 1}]
-            </a>
-          </sup>
-        </li>
-      ))}
-    </ul>
-  )
-}
-
-import { USE_JIT_DOMAINS } from '../config'
-
-export default function PropertyResults({ property }: { property: Property }) {
-  return (
-    <>
-      {!USE_JIT_DOMAINS && (
-        <>
-          {/* TODO: delete legacy Domains/Notes once JIT Domains fully launches */}
-          <div className="bg-gray-50 p-4 rounded mb-4">
-            <h3 className="font-medium">Domains</h3>
-            {renderList(property.domains)}
-          </div>
-          <div className="bg-gray-50 p-4 rounded mb-4">
-            <h3 className="font-medium mb-2">Notes</h3>
-            {renderList(property.notes)}
-          </div>
-        </>
-      )}
-      <div className="bg-gray-50 p-4 rounded mb-4">
-        <h3 className="font-medium">Confidence</h3>
-        <p>{Math.round(property.confidence * 100)}%</p>
-      </div>
-    </>
+    <div className="bg-gray-50 p-4 rounded mb-4">
+      <h3 className="font-medium">Confidence</h3>
+      <p>{Math.round(property.confidence * 100)}%</p>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- strip legacy Domains and Notes sections from PropertyResults
- clean AnalyzerCard navigation by dropping Footnotes link and section
- update tests for confidence-only property results

## Testing
- `black --check .`
- `ruff check .`
- `pytest`
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `pnpm build`
- `pnpm preview`


------
https://chatgpt.com/codex/tasks/task_e_688fb52e9378832981499e97797f70e0