### PR TITLE
Add AnalysisSnapshot schema with snapshot and timestamp

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,14 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model AnalysisSnapshot {
+  id          Int      @id @default(autoincrement())
+  snapshot    Json
+  generatedAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- define Prisma schema with AnalysisSnapshot model
- track snapshot JSON and generated timestamp

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma migrate dev --name add-analysis-snapshot` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... - 403 Forbidden)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fc4ef45208329b91a3789308741f7