### PR TITLE
feat: expose analysis snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ The gateway orchestrates the other APIs. Key endpoints:
 * `GET /health` – liveness probe.
 * `GET /ready` – checks that downstream services are healthy.
 * `GET /metrics` – optional stats about service calls.
-* `POST /analyze` – body `{"url": "https://example.com", "headless": false, "force": false}` returns:
-  `{"property": {...}, "martech": {...}}`.
+* `POST /analyze` – body `{"url": "https://example.com", "headless": false, "force": false}` returns
+  `{"property": {...}, "martech": {...}, "snapshot": {...}}`.
 * `POST /generate` – body `{"url": "https://example.com", "martech": {...}, "cms": [], "cms_manual": "WordPress"}` proxies to the insight service and returns persona and insight JSON.
 * `POST /insight` – body `{ "url": "https://example.com", "industry": "SaaS", "pain_point": "Slow onboarding", "stack": [{"category": "analytics", "vendor": "GA4"}] }` proxies to `INSIGHT_URL/insight` and returns `{ "markdown": "...", "degraded": false }`. The endpoint also accepts `{ "text": "notes" }` for free‑form analysis.
 * `INSIGHT_TIMEOUT` controls how long the gateway waits for an insight reply (default `30`s).
@@ -117,9 +117,22 @@ The gateway orchestrates the other APIs. Key endpoints:
 Example:
 
 ```bash
-curl -X POST http://localhost:8080/analyze \
+curl -sS -X POST http://localhost:8080/analyze \
   -H 'Content-Type: application/json' \
-  -d '{"url": "https://example.com"}'
+  -d '{"url": "https://example.com"}' | jq
+# {
+#   "property": { "domains": ["example.com"] },
+#   "martech": { "core": ["GA"] },
+#   "cms": [],
+#   "snapshot": {
+#     "profile": {},
+#     "digitalScore": {},
+#     "riskMatrix": {},
+#     "stackDelta": {},
+#     "growthTriggers": {},
+#     "nextActions": {}
+#   }
+# }
 ```
 
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,5 +1,24 @@
 # Gateway API Notes
 
+## POST /analyze
+
+Returns the core analysis artifacts. The response now includes a
+`snapshot` object that combines the profile, digital score, risk
+assessment and suggested next actions.
+
+### Snapshot schema
+
+```json
+{
+  "profile": {},
+  "digitalScore": {},
+  "riskMatrix": {},
+  "stackDelta": {},
+  "growthTriggers": {},
+  "nextActions": {}
+}
+```
+
 ## POST /generate
 
 Optional field `martech_manual` (array of objects with `category` and `vendor`) allows overriding or supplementing detected vendors. A legacy array of strings is still accepted for backward compatibility. Manual items appear first and duplicate entries from detected list are removed.

--- a/services/api/routes/analyze.ts
+++ b/services/api/routes/analyze.ts
@@ -1,0 +1,16 @@
+import { buildSnapshot, BuildSnapshotResult, Snapshot } from '../../analyze/buildSnapshot';
+
+export interface AnalyzeResponse {
+  snapshot: Snapshot;
+}
+
+/**
+ * Analyze the supplied artifacts and assemble a final snapshot.
+ *
+ * The handler expects the request body to match `BuildSnapshotResult`
+ * and returns the resulting snapshot inside a JSON object.
+ */
+export async function analyze(body: BuildSnapshotResult): Promise<AnalyzeResponse> {
+  const snapshot = buildSnapshot(body);
+  return { snapshot };
+}

--- a/services/insight/app.py
+++ b/services/insight/app.py
@@ -332,7 +332,7 @@ async def _generate_alt_text(description: str) -> str:
     if not os.getenv("OPENAI_API_KEY") or openai is None:
         return ""
     try:
-        alt, _ = await orchestrator.call_openai_with_retry(
+        alt, _, _ = await orchestrator.call_openai_with_retry(
             [
                 {
                     "role": "user",


### PR DESCRIPTION
## Summary
- include snapshot in analyze response
- document snapshot in OpenAPI notes and README
- fix alt text generation to match orchestrator return signature

## Testing
- `tox -e lint,type`
- `pytest tests/test_gateway.py::test_analyze_success -q`
- `pytest tests/test_property.py::test_analyze_success -q`


------
https://chatgpt.com/codex/tasks/task_e_688fce1250cc8329bb19779d5d25358f