### PR TITLE
feat(summary): add executive summary components

### DIFF
--- a/interface/src/components/index.ts
+++ b/interface/src/components/index.ts
@@ -15,3 +15,4 @@ export {
 } from './InsightMarkdown'
 export { default as MartechCategorySelector } from './MartechCategorySelector'
 
+export * from './summary'

--- a/interface/src/components/summary/CompanyProfileCard.tsx
+++ b/interface/src/components/summary/CompanyProfileCard.tsx
@@ -1,0 +1,53 @@
+import type { HTMLAttributes } from 'react'
+import clsx from 'clsx'
+
+export interface CompanyProfileProps extends HTMLAttributes<HTMLDivElement> {
+  name: string
+  website?: string
+  industry?: string
+  location?: string
+  logoUrl?: string
+}
+
+export default function CompanyProfileCard({
+  name,
+  website,
+  industry,
+  location,
+  logoUrl,
+  className,
+  ...props
+}: CompanyProfileProps) {
+  return (
+    <div
+      className={clsx(
+        'flex items-center gap-4 p-4 border rounded bg-white',
+        className,
+      )}
+      {...props}
+    >
+      {logoUrl && (
+        <img
+          src={logoUrl}
+          alt={`${name} logo`}
+          className="w-12 h-12 rounded object-cover"
+        />
+      )}
+      <div className="text-sm">
+        <div className="font-medium">{name}</div>
+        {industry && <div>{industry}</div>}
+        {location && <div>{location}</div>}
+        {website && (
+          <a
+            href={website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline break-all"
+          >
+            {website}
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/interface/src/components/summary/DigitalScoreBar.tsx
+++ b/interface/src/components/summary/DigitalScoreBar.tsx
@@ -1,0 +1,22 @@
+import clsx from 'clsx'
+
+export interface DigitalScoreBarProps {
+  score: number
+}
+
+export default function DigitalScoreBar({ score }: DigitalScoreBarProps) {
+  const bounded = Math.max(0, Math.min(100, score))
+  const color =
+    bounded >= 80 ? 'bg-green-500' : bounded >= 50 ? 'bg-yellow-500' : 'bg-red-500'
+  return (
+    <div>
+      <div className="text-sm mb-1">Digital Score: {bounded}</div>
+      <div className="h-2 bg-gray-200 rounded">
+        <div
+          className={clsx('h-full rounded', color)}
+          style={{ width: `${bounded}%` }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/interface/src/components/summary/ExecutiveSummaryCard.tsx
+++ b/interface/src/components/summary/ExecutiveSummaryCard.tsx
@@ -1,0 +1,45 @@
+import CompanyProfileCard, { type CompanyProfileProps } from './CompanyProfileCard'
+import DigitalScoreBar from './DigitalScoreBar'
+import MiniRiskMatrix, { type MiniRiskMatrixProps } from './MiniRiskMatrix'
+import StackDeltaRow, { type StackDeltaRowProps } from './StackDeltaRow'
+import GrowthTriggersList, { type GrowthTriggersListProps } from './GrowthTriggersList'
+import NextActionsChips, { type NextActionsChipsProps } from './NextActionsChips'
+
+export interface ExecutiveSummaryCardProps {
+  profile: CompanyProfileProps
+  score: number
+  risk?: MiniRiskMatrixProps['position']
+  stack: StackDeltaRowProps[]
+  triggers: GrowthTriggersListProps['triggers']
+  actions: NextActionsChipsProps['actions']
+}
+
+export default function ExecutiveSummaryCard({
+  profile,
+  score,
+  risk,
+  stack,
+  triggers,
+  actions,
+}: ExecutiveSummaryCardProps) {
+  return (
+    <article className="grid grid-cols-2 gap-4 p-4 bg-white rounded shadow max-h-[320px] overflow-auto">
+      <div className="col-span-2">
+        <CompanyProfileCard {...profile} />
+      </div>
+      <DigitalScoreBar score={score} />
+      <MiniRiskMatrix position={risk} />
+      <div className="col-span-2 space-y-1">
+        {stack.map((s) => (
+          <StackDeltaRow key={s.label} {...s} />
+        ))}
+      </div>
+      <div className="col-span-2">
+        <GrowthTriggersList triggers={triggers} />
+      </div>
+      <div className="col-span-2">
+        <NextActionsChips actions={actions} />
+      </div>
+    </article>
+  )
+}

--- a/interface/src/components/summary/GrowthTriggersList.tsx
+++ b/interface/src/components/summary/GrowthTriggersList.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+import Sheet from '../ui/sheet'
+
+export interface GrowthTriggersListProps {
+  triggers: string[]
+}
+
+export default function GrowthTriggersList({ triggers }: GrowthTriggersListProps) {
+  const [open, setOpen] = useState(false)
+  const visible = triggers.slice(0, 3)
+  const hidden = triggers.slice(3)
+  return (
+    <div className="text-sm">
+      <ul className="list-disc ml-4 space-y-1">
+        {visible.map((t, i) => (
+          <li key={i}>{t}</li>
+        ))}
+      </ul>
+      {hidden.length > 0 && (
+        <>
+          <button
+            onClick={() => setOpen(true)}
+            className="text-blue-600 text-sm mt-1"
+          >
+            +{hidden.length}
+          </button>
+          <Sheet open={open} onClose={() => setOpen(false)}>
+            <h2 className="font-medium mb-2">Growth Triggers</h2>
+            <ul className="list-disc ml-4 space-y-1">
+              {triggers.map((t, i) => (
+                <li key={i}>{t}</li>
+              ))}
+            </ul>
+          </Sheet>
+        </>
+      )}
+    </div>
+  )
+}

--- a/interface/src/components/summary/MiniRiskMatrix.tsx
+++ b/interface/src/components/summary/MiniRiskMatrix.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import type { JSX } from 'react'
 
 export interface MiniRiskMatrixProps {
   position?: { x: number; y: number }
@@ -21,7 +22,7 @@ export default function MiniRiskMatrix({ position, onClick }: MiniRiskMatrixProp
             'w-3 h-3 border',
             active ? 'bg-red-500' : 'bg-gray-100',
           )}
-        />,
+        />
       )
     }
   }

--- a/interface/src/components/summary/MiniRiskMatrix.tsx
+++ b/interface/src/components/summary/MiniRiskMatrix.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx'
+
+export interface MiniRiskMatrixProps {
+  position?: { x: number; y: number }
+  onClick?: () => void
+}
+
+export default function MiniRiskMatrix({ position, onClick }: MiniRiskMatrixProps) {
+  function handleClick() {
+    if (onClick) onClick()
+    else document.getElementById('healthchecks')?.scrollIntoView({ behavior: 'smooth' })
+  }
+  const cells: JSX.Element[] = []
+  for (let y = 0; y < 3; y++) {
+    for (let x = 0; x < 3; x++) {
+      const active = position && position.x === x && position.y === y
+      cells.push(
+        <div
+          key={`${x}-${y}`}
+          className={clsx(
+            'w-3 h-3 border',
+            active ? 'bg-red-500' : 'bg-gray-100',
+          )}
+        />,
+      )
+    }
+  }
+  return (
+    <button
+      aria-label="healthchecks"
+      onClick={handleClick}
+      className="grid grid-cols-3 grid-rows-3 gap-0.5"
+    >
+      {cells}
+    </button>
+  )
+}

--- a/interface/src/components/summary/NextActionsChips.tsx
+++ b/interface/src/components/summary/NextActionsChips.tsx
@@ -1,0 +1,27 @@
+export interface NextAction {
+  label: string
+  targetId: string
+}
+
+export interface NextActionsChipsProps {
+  actions: NextAction[]
+}
+
+export default function NextActionsChips({ actions }: NextActionsChipsProps) {
+  function scroll(id: string) {
+    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' })
+  }
+  return (
+    <div className="flex flex-wrap gap-2">
+      {actions.map((a) => (
+        <button
+          key={a.targetId}
+          onClick={() => scroll(a.targetId)}
+          className="px-2 py-1 text-sm border rounded-full bg-gray-100"
+        >
+          {a.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/interface/src/components/summary/StackDeltaRow.tsx
+++ b/interface/src/components/summary/StackDeltaRow.tsx
@@ -1,0 +1,23 @@
+import { PlusCircleIcon, MinusCircleIcon, ArrowPathIcon } from '@heroicons/react/24/solid'
+
+export interface StackDeltaRowProps {
+  label: string
+  status: 'added' | 'removed' | 'changed'
+}
+
+export default function StackDeltaRow({ label, status }: StackDeltaRowProps) {
+  const icon =
+    status === 'added' ? (
+      <PlusCircleIcon className="w-5 h-5 text-green-600" />
+    ) : status === 'removed' ? (
+      <MinusCircleIcon className="w-5 h-5 text-red-600" />
+    ) : (
+      <ArrowPathIcon className="w-5 h-5 text-yellow-600" />
+    )
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      {icon}
+      <span>{label}</span>
+    </div>
+  )
+}

--- a/interface/src/components/summary/index.ts
+++ b/interface/src/components/summary/index.ts
@@ -1,0 +1,29 @@
+export {
+  default as CompanyProfileCard,
+  type CompanyProfileProps,
+} from './CompanyProfileCard'
+export {
+  default as DigitalScoreBar,
+  type DigitalScoreBarProps,
+} from './DigitalScoreBar'
+export {
+  default as MiniRiskMatrix,
+  type MiniRiskMatrixProps,
+} from './MiniRiskMatrix'
+export {
+  default as StackDeltaRow,
+  type StackDeltaRowProps,
+} from './StackDeltaRow'
+export {
+  default as GrowthTriggersList,
+  type GrowthTriggersListProps,
+} from './GrowthTriggersList'
+export {
+  default as NextActionsChips,
+  type NextActionsChipsProps,
+  type NextAction,
+} from './NextActionsChips'
+export {
+  default as ExecutiveSummaryCard,
+  type ExecutiveSummaryCardProps,
+} from './ExecutiveSummaryCard'


### PR DESCRIPTION
## Summary
- add summary components for company profile, score, risk matrix, stack changes, growth triggers, and next actions
- expose summary components via components index for reuse

## Testing
- `pytest`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fd0c725d8832989a11755e2d575f3