### PR TITLE
feat: improve summary accessibility and color palette

### DIFF
--- a/interface/src/components/summary/DigitalScoreBar.tsx
+++ b/interface/src/components/summary/DigitalScoreBar.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx'
+import { COLOR_BLIND_PALETTE } from './palette'
 
 export interface DigitalScoreBarProps {
   score: number
@@ -7,14 +7,18 @@ export interface DigitalScoreBarProps {
 export default function DigitalScoreBar({ score }: DigitalScoreBarProps) {
   const bounded = Math.max(0, Math.min(100, score))
   const color =
-    bounded >= 80 ? 'bg-green-500' : bounded >= 50 ? 'bg-yellow-500' : 'bg-red-500'
+    bounded >= 80
+      ? COLOR_BLIND_PALETTE.green
+      : bounded >= 50
+        ? COLOR_BLIND_PALETTE.amber
+        : COLOR_BLIND_PALETTE.red
   return (
     <div>
       <div className="text-sm mb-1">Digital Score: {bounded}</div>
       <div className="h-2 bg-gray-200 rounded">
         <div
-          className={clsx('h-full rounded', color)}
-          style={{ width: `${bounded}%` }}
+          className="h-full rounded"
+          style={{ width: `${bounded}%`, backgroundColor: color }}
         />
       </div>
     </div>

--- a/interface/src/components/summary/ExecutiveSummaryCard.tsx
+++ b/interface/src/components/summary/ExecutiveSummaryCard.tsx
@@ -23,23 +23,28 @@ export default function ExecutiveSummaryCard({
   actions,
 }: ExecutiveSummaryCardProps) {
   return (
-    <article className="grid grid-cols-2 gap-4 p-4 bg-white rounded shadow max-h-[320px] overflow-auto">
-      <div className="col-span-2">
-        <CompanyProfileCard {...profile} />
-      </div>
-      <DigitalScoreBar score={score} />
-      <MiniRiskMatrix position={risk} />
-      <div className="col-span-2 space-y-1">
-        {stack.map((s) => (
-          <StackDeltaRow key={s.label} {...s} />
-        ))}
-      </div>
-      <div className="col-span-2">
-        <GrowthTriggersList triggers={triggers} />
-      </div>
-      <div className="col-span-2">
-        <NextActionsChips actions={actions} />
-      </div>
-    </article>
+    <section aria-labelledby="exec-summary-heading">
+      <h2 id="exec-summary-heading" className="sr-only">
+        Executive Summary
+      </h2>
+      <article className="grid grid-cols-2 gap-4 p-4 bg-white rounded shadow max-h-[320px] overflow-auto">
+        <div className="col-span-2">
+          <CompanyProfileCard {...profile} />
+        </div>
+        <DigitalScoreBar score={score} />
+        <MiniRiskMatrix position={risk} />
+        <div className="col-span-2 space-y-1">
+          {stack.map((s) => (
+            <StackDeltaRow key={s.label} {...s} />
+          ))}
+        </div>
+        <div className="col-span-2">
+          <GrowthTriggersList triggers={triggers} />
+        </div>
+        <div className="col-span-2">
+          <NextActionsChips actions={actions} />
+        </div>
+      </article>
+    </section>
   )
 }

--- a/interface/src/components/summary/GrowthTriggersList.tsx
+++ b/interface/src/components/summary/GrowthTriggersList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import Sheet from '../ui/sheet'
 
 export interface GrowthTriggersListProps {
@@ -9,11 +9,32 @@ export default function GrowthTriggersList({ triggers }: GrowthTriggersListProps
   const [open, setOpen] = useState(false)
   const visible = triggers.slice(0, 3)
   const hidden = triggers.slice(3)
+  const itemRefs = useRef<Array<HTMLLIElement | null>>([])
+
+  function handleKeyDown(
+    e: React.KeyboardEvent<HTMLLIElement>,
+    idx: number,
+  ) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      itemRefs.current[(idx + 1) % visible.length]?.focus()
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      itemRefs.current[(idx - 1 + visible.length) % visible.length]?.focus()
+    }
+  }
   return (
     <div className="text-sm">
-      <ul className="list-disc ml-4 space-y-1">
+      <ul className="list-disc ml-4 space-y-1" role="list">
         {visible.map((t, i) => (
-          <li key={i}>{t}</li>
+          <li
+            key={i}
+            ref={(el) => (itemRefs.current[i] = el)}
+            tabIndex={0}
+            onKeyDown={(e) => handleKeyDown(e, i)}
+          >
+            {t}
+          </li>
         ))}
       </ul>
       {hidden.length > 0 && (

--- a/interface/src/components/summary/MiniRiskMatrix.tsx
+++ b/interface/src/components/summary/MiniRiskMatrix.tsx
@@ -1,5 +1,5 @@
-import clsx from 'clsx'
 import type { JSX } from 'react'
+import { COLOR_BLIND_PALETTE } from './palette'
 
 export interface MiniRiskMatrixProps {
   position?: { x: number; y: number }
@@ -18,10 +18,12 @@ export default function MiniRiskMatrix({ position, onClick }: MiniRiskMatrixProp
       cells.push(
         <div
           key={`${x}-${y}`}
-          className={clsx(
-            'w-3 h-3 border',
-            active ? 'bg-red-500' : 'bg-gray-100',
-          )}
+          className="w-3 h-3 border"
+          style={{
+            backgroundColor: active
+              ? COLOR_BLIND_PALETTE.red
+              : '#f3f4f6',
+          }}
         />
       )
     }

--- a/interface/src/components/summary/NextActionsChips.tsx
+++ b/interface/src/components/summary/NextActionsChips.tsx
@@ -1,3 +1,5 @@
+import { useRef } from 'react'
+
 export interface NextAction {
   label: string
   targetId: string
@@ -8,20 +10,39 @@ export interface NextActionsChipsProps {
 }
 
 export default function NextActionsChips({ actions }: NextActionsChipsProps) {
+  const btnRefs = useRef<Array<HTMLButtonElement | null>>([])
+
   function scroll(id: string) {
     document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' })
   }
+
+  function handleKeyDown(
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    idx: number,
+  ) {
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      btnRefs.current[(idx + 1) % actions.length]?.focus()
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      btnRefs.current[(idx - 1 + actions.length) % actions.length]?.focus()
+    }
+  }
+
   return (
-    <div className="flex flex-wrap gap-2">
-      {actions.map((a) => (
-        <button
-          key={a.targetId}
-          onClick={() => scroll(a.targetId)}
-          className="px-2 py-1 text-sm border rounded-full bg-gray-100"
-        >
-          {a.label}
-        </button>
+    <ul className="flex flex-wrap gap-2" role="list">
+      {actions.map((a, i) => (
+        <li key={a.targetId}>
+          <button
+            ref={(el) => (btnRefs.current[i] = el)}
+            onClick={() => scroll(a.targetId)}
+            onKeyDown={(e) => handleKeyDown(e, i)}
+            className="px-2 py-1 text-sm border rounded-full bg-gray-100"
+          >
+            {a.label}
+          </button>
+        </li>
       ))}
-    </div>
+    </ul>
   )
 }

--- a/interface/src/components/summary/StackDeltaRow.tsx
+++ b/interface/src/components/summary/StackDeltaRow.tsx
@@ -1,4 +1,5 @@
 import { PlusCircleIcon, MinusCircleIcon, ArrowPathIcon } from '@heroicons/react/24/solid'
+import { COLOR_BLIND_PALETTE } from './palette'
 
 export interface StackDeltaRowProps {
   label: string
@@ -8,11 +9,20 @@ export interface StackDeltaRowProps {
 export default function StackDeltaRow({ label, status }: StackDeltaRowProps) {
   const icon =
     status === 'added' ? (
-      <PlusCircleIcon className="w-5 h-5 text-green-600" />
+      <PlusCircleIcon
+        className="w-5 h-5"
+        style={{ color: COLOR_BLIND_PALETTE.green }}
+      />
     ) : status === 'removed' ? (
-      <MinusCircleIcon className="w-5 h-5 text-red-600" />
+      <MinusCircleIcon
+        className="w-5 h-5"
+        style={{ color: COLOR_BLIND_PALETTE.red }}
+      />
     ) : (
-      <ArrowPathIcon className="w-5 h-5 text-yellow-600" />
+      <ArrowPathIcon
+        className="w-5 h-5"
+        style={{ color: COLOR_BLIND_PALETTE.amber }}
+      />
     )
   return (
     <div className="flex items-center gap-2 text-sm">

--- a/interface/src/components/summary/palette.ts
+++ b/interface/src/components/summary/palette.ts
@@ -1,0 +1,7 @@
+export const COLOR_BLIND_PALETTE = {
+  red: '#D55E00',
+  amber: '#E69F00',
+  green: '#009E73',
+} as const
+
+export type PaletteColor = keyof typeof COLOR_BLIND_PALETTE


### PR DESCRIPTION
## Summary
- wrap ExecutiveSummaryCard in a `<section>` labeled by `exec-summary-heading`
- add keyboard navigation for growth triggers and next actions lists
- switch summary visuals to a color-blind safe red/amber/green palette

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fd842b5a4832994f11a63e3fe0c9f