### PR TITLE
Add responsive stacking and mobile accordion

### DIFF
--- a/interface/src/components/summary/ExecutiveSummaryCard.tsx
+++ b/interface/src/components/summary/ExecutiveSummaryCard.tsx
@@ -27,21 +27,21 @@ export default function ExecutiveSummaryCard({
       <h2 id="exec-summary-heading" className="sr-only">
         Executive Summary
       </h2>
-      <article className="grid grid-cols-2 gap-4 p-4 bg-white rounded shadow max-h-[320px] overflow-auto">
-        <div className="col-span-2">
+      <article className="grid grid-cols-1 xs:grid-cols-2 gap-4 p-4 bg-white rounded shadow max-h-[320px] overflow-auto">
+        <div className="xs:col-span-2">
           <CompanyProfileCard {...profile} />
         </div>
         <DigitalScoreBar score={score} />
         <MiniRiskMatrix position={risk} />
-        <div className="col-span-2 space-y-1">
+        <div className="xs:col-span-2 space-y-1">
           {stack.map((s) => (
             <StackDeltaRow key={s.label} {...s} />
           ))}
         </div>
-        <div className="col-span-2">
+        <div className="xs:col-span-2">
           <GrowthTriggersList triggers={triggers} />
         </div>
-        <div className="col-span-2">
+        <div className="xs:col-span-2">
           <NextActionsChips actions={actions} />
         </div>
       </article>

--- a/interface/src/components/summary/GrowthTriggersList.tsx
+++ b/interface/src/components/summary/GrowthTriggersList.tsx
@@ -1,5 +1,11 @@
 import { useRef, useState } from 'react'
 import Sheet from '../ui/sheet'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '../ui/accordion'
 
 export interface GrowthTriggersListProps {
   triggers: string[]
@@ -23,40 +29,59 @@ export default function GrowthTriggersList({ triggers }: GrowthTriggersListProps
       itemRefs.current[(idx - 1 + visible.length) % visible.length]?.focus()
     }
   }
+
+  const list = (
+    <ul className="list-disc ml-4 space-y-1" role="list">
+      {visible.map((t, i) => (
+        <li
+          key={i}
+          ref={(el) => {
+            itemRefs.current[i] = el
+          }}
+          tabIndex={0}
+          onKeyDown={(e) => handleKeyDown(e, i)}
+        >
+          {t}
+        </li>
+      ))}
+    </ul>
+  )
+
   return (
-    <div className="text-sm">
-      <ul className="list-disc ml-4 space-y-1" role="list">
-        {visible.map((t, i) => (
-          <li
-            key={i}
-            ref={(el) => {
-              itemRefs.current[i] = el
-            }}
-            tabIndex={0}
-            onKeyDown={(e) => handleKeyDown(e, i)}
-          >
-            {t}
-          </li>
-        ))}
-      </ul>
-      {hidden.length > 0 && (
-        <>
-          <button
-            onClick={() => setOpen(true)}
-            className="text-blue-600 text-sm mt-1"
-          >
-            +{hidden.length}
-          </button>
-          <Sheet open={open} onClose={() => setOpen(false)}>
-            <h2 className="font-medium mb-2">Growth Triggers</h2>
+    <>
+      <div className="hidden xs:block text-sm">
+        {list}
+        {hidden.length > 0 && (
+          <>
+            <button
+              onClick={() => setOpen(true)}
+              className="text-blue-600 text-sm mt-1"
+            >
+              +{hidden.length}
+            </button>
+            <Sheet open={open} onClose={() => setOpen(false)}>
+              <h2 className="font-medium mb-2">Growth Triggers</h2>
+              <ul className="list-disc ml-4 space-y-1">
+                {triggers.map((t, i) => (
+                  <li key={i}>{t}</li>
+                ))}
+              </ul>
+            </Sheet>
+          </>
+        )}
+      </div>
+      <Accordion type="single" collapsible className="block xs:hidden text-sm">
+        <AccordionItem value="triggers">
+          <AccordionTrigger>Growth Triggers</AccordionTrigger>
+          <AccordionContent>
             <ul className="list-disc ml-4 space-y-1">
               {triggers.map((t, i) => (
                 <li key={i}>{t}</li>
               ))}
             </ul>
-          </Sheet>
-        </>
-      )}
-    </div>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </>
   )
 }

--- a/interface/tailwind.config.js
+++ b/interface/tailwind.config.js
@@ -15,6 +15,9 @@ export default {
       }
     },
     extend: {
+      screens: {
+        xs: '375px'
+      },
       colors: {
         primary: {
           DEFAULT: '#ff7c0a',


### PR DESCRIPTION
## Summary
- stack summary card blocks on screens narrower than 375px
- collapse growth triggers into a mobile accordion
- ensure executive summary card is capped at 320px height

## Testing
- `pre-commit run --files interface/tailwind.config.js interface/src/components/summary/ExecutiveSummaryCard.tsx interface/src/components/summary/GrowthTriggersList.tsx`
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688fddc51230832992abdf56355175c4