### PR TITLE
test: verify growth triggers capped

### DIFF
--- a/interface/cypress/e2e/domain_analysis.cy.ts
+++ b/interface/cypress/e2e/domain_analysis.cy.ts
@@ -1,0 +1,20 @@
+describe('Domain analysis flow', () => {
+  it('limits growth triggers to three', () => {
+    cy.intercept('GET', '/analyze', {
+      statusCode: 200,
+      body: {
+        snapshot: {
+          profile: { name: 'Acme Corp' },
+          digitalScore: 75,
+          stackDelta: [],
+          growthTriggers: ['one', 'two', 'three', 'four'],
+          nextActions: [],
+        },
+      },
+    }).as('analyze')
+
+    cy.visit('/analysis')
+    cy.wait('@analyze')
+    cy.get('li[data-testid="growth-trigger"]').should('have.length.at.most', 3)
+  })
+})

--- a/interface/src/api.ts
+++ b/interface/src/api.ts
@@ -1,6 +1,6 @@
 export const BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
 
-if (!BASE_URL) {
+if (!BASE_URL && import.meta.env.MODE !== 'test') {
   console.warn('API base URL not configured \u2013 check `.env`')
 }
 

--- a/interface/src/components/summary/GrowthTriggersList.tsx
+++ b/interface/src/components/summary/GrowthTriggersList.tsx
@@ -35,6 +35,7 @@ export default function GrowthTriggersList({ triggers }: GrowthTriggersListProps
       {visible.map((t, i) => (
         <li
           key={i}
+          data-testid="growth-trigger"
           ref={(el) => {
             itemRefs.current[i] = el
           }}
@@ -63,7 +64,9 @@ export default function GrowthTriggersList({ triggers }: GrowthTriggersListProps
               <h2 className="font-medium mb-2">Growth Triggers</h2>
               <ul className="list-disc ml-4 space-y-1">
                 {triggers.map((t, i) => (
-                  <li key={i}>{t}</li>
+                  <li key={i} data-testid="growth-trigger">
+                    {t}
+                  </li>
                 ))}
               </ul>
             </Sheet>
@@ -76,7 +79,9 @@ export default function GrowthTriggersList({ triggers }: GrowthTriggersListProps
           <AccordionContent>
             <ul className="list-disc ml-4 space-y-1">
               {triggers.map((t, i) => (
-                <li key={i}>{t}</li>
+                <li key={i} data-testid="growth-trigger">
+                  {t}
+                </li>
               ))}
             </ul>
           </AccordionContent>

--- a/interface/src/components/summary/__snapshots__/ExecutiveSummaryCard.test.tsx.snap
+++ b/interface/src/components/summary/__snapshots__/ExecutiveSummaryCard.test.tsx.snap
@@ -158,11 +158,13 @@ exports[`renders executive summary snapshot 1`] = `
             role="list"
           >
             <li
+              data-testid="growth-trigger"
               tabindex="0"
             >
               Add chat widget
             </li>
             <li
+              data-testid="growth-trigger"
               tabindex="0"
             >
               Improve SEO

--- a/interface/src/main.tsx
+++ b/interface/src/main.tsx
@@ -8,14 +8,18 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import AnalysisResultPage from './pages/AnalysisResultPage'
 import { ErrorBoundary } from './components'
 import { DomainProvider } from './contexts/DomainContext'
+
+const RootComponent =
+  window.location.pathname === '/analysis' ? AnalysisResultPage : App
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <DomainProvider>
       <ErrorBoundary>
-        <App />
+        <RootComponent />
       </ErrorBoundary>
     </DomainProvider>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- route `/analysis` to dedicated analysis results page
- tag growth trigger list items for Cypress checks
- add Cypress test ensuring at most three growth triggers render

## Testing
- `npm test --prefix interface`

------
https://chatgpt.com/codex/tasks/task_e_688fe531c37883298b48bd5c1e9b537e