### PR TITLE
feat: fetch analysis snapshot via POST

### DIFF
--- a/interface/cypress/e2e/domain_analysis.cy.ts
+++ b/interface/cypress/e2e/domain_analysis.cy.ts
@@ -1,6 +1,6 @@
 describe('Domain analysis flow', () => {
   it('limits growth triggers to three', () => {
-    cy.intercept('GET', '/analyze', {
+    cy.intercept('POST', '/analyze', {
       statusCode: 200,
       body: {
         snapshot: {

--- a/interface/src/pages/AnalysisResultPage.tsx
+++ b/interface/src/pages/AnalysisResultPage.tsx
@@ -13,15 +13,33 @@ type Snapshot = {
 
 export default function AnalysisResultPage() {
   const [snapshot, setSnapshot] = useState<Snapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
 
   useEffect(() => {
     async function load() {
-      const data = await apiFetch<{ snapshot: Snapshot }>('/analyze')
-      setSnapshot(data.snapshot)
+      try {
+        setLoading(true)
+        const data = await apiFetch<{ snapshot: Snapshot }>(
+          '/analyze',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url: 'https://example.com' }),
+          },
+        )
+        setSnapshot(data.snapshot)
+      } catch {
+        setError('Failed to load analysis')
+      } finally {
+        setLoading(false)
+      }
     }
     void load()
   }, [])
 
+  if (loading) return <div className="p-4">Loading...</div>
+  if (error) return <div className="p-4 text-red-600">{error}</div>
   if (!snapshot) return null
 
   const triggers =


### PR DESCRIPTION
## Summary
- fetch snapshot from `/analyze` via POST
- handle loading and error states on AnalysisResultPage
- adjust cypress intercept for POST

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68900bd698bc8329bf4a28e42a2d1394