### PR TITLE
Add snapshot endpoint

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -35,3 +35,23 @@ Optional field `martech_manual` (array of objects with `category` and `vendor`) 
   "cms": ["WordPress"]
 }
 ```
+
+## POST /snapshot
+
+Assemble a final analysis snapshot from previously generated artifacts.
+
+The request body matches the snapshot schema above and the endpoint responds
+with the assembled object:
+
+```json
+{
+  "snapshot": {
+    "profile": {},
+    "digitalScore": {},
+    "riskMatrix": {},
+    "stackDelta": {},
+    "growthTriggers": [],
+    "nextActions": {}
+  }
+}
+```

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -473,3 +473,21 @@ def test_generate_accepts_legacy_list(monkeypatch):
     )
     assert r.status_code == 200
     assert r.json()["result"] == {"ok": True}
+
+
+def test_snapshot_endpoint():
+    r = client.post(
+        "/snapshot",
+        json={
+            "profile": {"name": "ACME"},
+            "digitalScore": 88,
+            "riskMatrix": {"risk": "low"},
+            "stackDelta": {"added": [], "removed": []},
+            "growthTriggers": ["trigger"],
+            "nextActions": {"todo": "something"},
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()["snapshot"]
+    assert data["profile"]["name"] == "ACME"
+    assert data["growthTriggers"] == ["trigger"]


### PR DESCRIPTION
## Summary
- build final Snapshot artifacts in gateway using a Python port of buildSnapshot
- expose POST /snapshot to assemble and return Snapshot JSON
- document snapshot endpoint in Gateway API docs

## Testing
- `pytest tests/test_gateway.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68900f5db3788329a084c86259db2de3