### PR TITLE
feat: show summary after analysis

### DIFF
--- a/interface/src/App.test.tsx
+++ b/interface/src/App.test.tsx
@@ -99,3 +99,37 @@ test('shows degraded banner when martech is null', async () => {
   await screen.findByRole('heading', { name: 'Confidence' })
   await screen.findByText(/partial results/i)
 })
+
+test('renders executive summary when snapshot returned', async () => {
+  const snapshot = {
+    profile: { name: 'Acme Inc.' },
+    digitalScore: 88,
+    stackDelta: [],
+    growthTriggers: ['Trigger'],
+    nextActions: [],
+  }
+  server.use(
+    http.post('/analyze', async ({ request }) => {
+      const body = await request.json()
+      expect(body).toEqual({
+        url: 'https://example.com',
+        headless: false,
+        force: false,
+        domains: [],
+      })
+      return Response.json({ snapshot })
+    }),
+  )
+  render(
+    <DomainProvider>
+      <App />
+    </DomainProvider>,
+  )
+  const input = screen.getByPlaceholderText('https://example.com')
+  await userEvent.type(input, 'example.com')
+  await userEvent.click(screen.getByRole('button', { name: /analyze/i }))
+  await screen.findByText('Acme Inc.')
+  expect(
+    screen.queryByRole('button', { name: /analyze/i }),
+  ).not.toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- Render ExecutiveSummaryCard when `/analyze` returns a snapshot
- Store snapshot in state and hide the analyzer view once analysis completes
- Test executive-summary navigation

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689011dc4cdc8329a852d093292b650d