### PR TITLE
docs: update interface summary docs

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -23,8 +23,7 @@ Open `http://localhost:5173` in your browser and start analyzing URLs.
 Set `VITE_USE_JIT_DOMAINS=true` to enable the just-in-time domain scope controls.
 
 The analyzer form includes a **Technology Stack** picker, an **Industry**
-dropdown, and a **Pain Point** text box for additional context. Generated
-insights can be downloaded via the **Export Markdown** button.
+dropdown, and a **Pain Point** text box for additional context.
 
 ## Building and running
 
@@ -40,12 +39,18 @@ The interface **requires** `VITE_API_BASE_URL` in `.env` so it knows where the
 API is running. The template now defaults to `http://localhost:8080`. Update
 this value to point at your deployed gateway as needed.
 
-The gateway's `/insight` endpoint proxies to `INSIGHT_URL`.
-Make sure `OPENAI_API_KEY` is set in that service's environment so it can reach the OpenAI API.
+The gateway's `/snapshot` endpoint assembles the final analysis snapshot.
+Make sure the upstream insight service has `OPENAI_API_KEY` set so it can reach the OpenAI API.
 
-## Insight display
+## Executive summary
 
-The analysis result now includes an "Executive Summary" showing a short
-insight fetched from the gateway. When a user clicks **Generate
-Insights** the frontend calls `/insight` which returns markdown. The
-markdown is rendered directly by `InsightCard`.
+The frontend posts the target URL to `/analyze` on the gateway. The
+gateway gathers property details, detects martech vendors and assembles a
+structured `snapshot` containing the company profile, digital score, risk
+matrix, stack changes, growth triggers and next-best actions. The
+snapshot is rendered by `ExecutiveSummaryCard` instead of the legacy
+markdown-based `InsightCard`.
+
+If you already have the intermediate artifacts, you can POST them to
+`/snapshot` to assemble the same summary. Set `VITE_API_BASE_URL` in
+`.env` so the interface knows where to reach these endpoints.


### PR DESCRIPTION
## Summary
- document ExecutiveSummaryCard and snapshot endpoint
- drop legacy /insight and InsightCard references

## Testing
- `pytest`
- `npm test` *(fails: Unable to find role="heading" and name "Confidence" in src/App.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689014ad0e848329bfbdb8004d90cde1