### PR TITLE
test: ensure exec summary card renders without legacy section

### DIFF
--- a/interface/src/pages/AnalysisResultPage.test.tsx
+++ b/interface/src/pages/AnalysisResultPage.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { test, expect } from 'vitest'
+import { server } from '../setupTests'
+import { http } from 'msw'
+import AnalysisResultPage from './AnalysisResultPage'
+
+test('renders ExecutiveSummaryCard when snapshot data present without legacy exec-summary section', async () => {
+  server.use(
+    http.post('/analyze', () =>
+      Response.json({
+        snapshot: {
+          profile: {
+            name: 'Acme Inc',
+            industry: 'SaaS',
+            location: 'NYC',
+            website: 'https://acme.com',
+          },
+          digitalScore: 80,
+          riskMatrix: { x: 1, y: 2 },
+          stackDelta: [{ label: 'React', status: 'added' }],
+          growthTriggers: ['Improve SEO'],
+          nextActions: [{ label: 'Analyze stack', targetId: 'stack' }],
+        },
+      }),
+    ),
+  )
+
+  render(<AnalysisResultPage />)
+  await screen.findByRole('heading', { name: /Executive Summary/i })
+  expect(screen.getByText('Acme Inc')).toBeInTheDocument()
+  expect(document.querySelector('#exec-summary')).toBeNull()
+})


### PR DESCRIPTION
## Summary
- add AnalysisResultPage test to assert ExecutiveSummaryCard renders from snapshot
- guard against reintroducing legacy `#exec-summary` section

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890237adcc48329a9cd1667eecb7793