### PR TITLE
chore: configure frontend gateway url

### DIFF
--- a/interface/.env
+++ b/interface/.env
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=http://localhost:8080
+


### PR DESCRIPTION
## Summary
- point the interface to the gateway via `VITE_API_BASE_URL`

## Testing
- `pytest`
- `npm test`
- `curl -s -o /tmp/curl_out.json -w '%{http_code}\n' http://localhost:8080/snapshot -H 'Content-Type: application/json' -d '{"profile":{},"digitalScore":{},"riskMatrix":{},"stackDelta":{},"growthTriggers":[],"nextActions":{}}'`


------
https://chatgpt.com/codex/tasks/task_e_68904acde060832991dfe97dac05beee