### PR TITLE
feat(interface): target gateway in snapshot requests

### DIFF
--- a/interface/src/App.test.tsx
+++ b/interface/src/App.test.tsx
@@ -22,7 +22,7 @@ test('renders executive summary when snapshot returned', async () => {
     nextActions: [],
   }
   server.use(
-    http.post('/snapshot', async () => {
+    http.post('http://localhost:8080/snapshot', async () => {
       return Response.json({ snapshot })
     }),
   )
@@ -42,7 +42,7 @@ test('renders executive summary when snapshot returned', async () => {
 
 test('shows error banner when request fails', async () => {
   server.use(
-    http.post('/snapshot', () => new Response(null, { status: 500 })),
+    http.post('http://localhost:8080/snapshot', () => new Response(null, { status: 500 })),
   )
   render(
     <DomainProvider>

--- a/interface/src/api.ts
+++ b/interface/src/api.ts
@@ -1,7 +1,14 @@
-export const BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+const envBase = import.meta.env.VITE_API_BASE_URL
+// Fall back to the gateway on port 8080 so requests don't hit the static server.
+const fallback =
+  typeof window !== 'undefined'
+    ? `${window.location.protocol}//${window.location.hostname}:8080`
+    : ''
 
-if (!BASE_URL && import.meta.env.MODE !== 'test') {
-  console.warn('API base URL not configured \u2013 check `.env`')
+export const BASE_URL = envBase || fallback
+
+if (!envBase && import.meta.env.MODE !== 'test') {
+  console.warn('API base URL not configured – check `.env`')
 }
 
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {

--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -130,7 +130,7 @@ test('displays insight text', async () => {
 test('shows skeleton while generating', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async () => {
+    http.post('http://localhost:8080/insight', async () => {
       await new Promise((r) => setTimeout(r, 50))
       return Response.json({ markdown: 'done', degraded: false })
     }),
@@ -163,7 +163,7 @@ test('shows skeleton while generating', async () => {
 test('keeps skeleton height during delayed insight response', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async () => {
+    http.post('http://localhost:8080/insight', async () => {
       await new Promise((r) => setTimeout(r, 100))
       return Response.json({ markdown: 'done', degraded: false })
     }),
@@ -201,7 +201,7 @@ test('shows generated details on success', async () => {
   let captured: any = null
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async ({ request }) => {
+    http.post('http://localhost:8080/insight', async ({ request }) => {
       captured = await request.json()
       return Response.json({ markdown: 'Flow', degraded: false })
     }),
@@ -249,7 +249,7 @@ test('shows generated details on success', async () => {
 test('hides skeleton on error', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async () => {
+    http.post('http://localhost:8080/insight', async () => {
       await new Promise((r) => setTimeout(r, 50))
       return new Response('fail', { status: 500 })
     }),
@@ -282,7 +282,7 @@ test('hides skeleton on error', async () => {
 test('renders empty markdown without fallback', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async () => Response.json({ markdown: '', degraded: false })),
+    http.post('http://localhost:8080/insight', async () => Response.json({ markdown: '', degraded: false })),
   )
   render(
     <AnalyzerCard
@@ -310,7 +310,7 @@ test('renders empty markdown without fallback', async () => {
 test('shows banner when insight degraded', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async () =>
+    http.post('http://localhost:8080/insight', async () =>
       Response.json({
         markdown: '## Next-Best Actions\n- A',
         degraded: true,
@@ -341,7 +341,7 @@ test('shows banner when insight degraded', async () => {
 test('shows banner when actions missing', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async () =>
+    http.post('http://localhost:8080/insight', async () =>
       Response.json({ markdown: '# Hi', degraded: false }),
     ),
   )
@@ -369,7 +369,7 @@ test('shows banner when actions missing', async () => {
 test('nudge opens context panel and keeps content', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async () =>
+    http.post('http://localhost:8080/insight', async () =>
       Response.json({ markdown: 'Hi', degraded: false }),
     ),
   )
@@ -402,7 +402,7 @@ test('nudge opens context panel and keeps content', async () => {
 test('shows error when generation fails', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', () => new Response(null, { status: 500 }))
+    http.post('http://localhost:8080/insight', () => new Response(null, { status: 500 }))
   )
   render(
     <AnalyzerCard
@@ -439,7 +439,7 @@ test('shows validation error and skips POST on invalid payload', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   const spy = vi.fn()
   server.use(
-    http.post('/insight', async ({ request }) => {
+    http.post('http://localhost:8080/insight', async ({ request }) => {
       const body = await request.json()
       if (
         body &&
@@ -483,7 +483,7 @@ test('chips reflect live values', async () => {
   sessionStorage.setItem('pain_point', 'Latency')
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async () =>
+    http.post('http://localhost:8080/insight', async () =>
       Response.json({ markdown: 'Hi', degraded: false }),
     ),
   )
@@ -524,7 +524,7 @@ test('chip clicks focus corresponding inputs', async () => {
   sessionStorage.setItem('pain_point', 'Billing')
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async () =>
+    http.post('http://localhost:8080/insight', async () =>
       Response.json({ markdown: 'Hi', degraded: false }),
     ),
   )
@@ -561,7 +561,7 @@ test('context strength updates with field edits', async () => {
   sessionStorage.setItem('pain_point', 'Billing')
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   server.use(
-    http.post('/insight', async () =>
+    http.post('http://localhost:8080/insight', async () =>
       Response.json({ markdown: 'Hi', degraded: false }),
     ),
   )

--- a/interface/src/pages/AnalysisResultPage.test.tsx
+++ b/interface/src/pages/AnalysisResultPage.test.tsx
@@ -6,7 +6,7 @@ import AnalysisResultPage from './AnalysisResultPage'
 
 test('renders ExecutiveSummaryCard when snapshot data present without legacy exec-summary section', async () => {
   server.use(
-    http.post('/snapshot', () =>
+    http.post('http://localhost:8080/snapshot', () =>
       Response.json({
         snapshot: {
           profile: {

--- a/interface/src/setupTests.ts
+++ b/interface/src/setupTests.ts
@@ -3,9 +3,11 @@ import '@testing-library/jest-dom'
 import { setupServer } from 'msw/node'
 import { http } from 'msw'
 
+const BASE = 'http://localhost:8080'
+
 export const server = setupServer(
-  http.get('/ready', () => Response.json({ ready: true })),
-  http.post('/snapshot', () =>
+  http.get(`${BASE}/ready`, () => Response.json({ ready: true })),
+  http.post(`${BASE}/snapshot`, () =>
     Response.json({
       snapshot: {
         profile: { name: 'Example Co' },
@@ -16,12 +18,12 @@ export const server = setupServer(
       },
     }),
   ),
-  http.post('/insight', () =>
+  http.post(`${BASE}/insight`, () =>
     Response.json({ markdown: 'Test insight', degraded: false }),
   ),
 )
 
-vi.stubEnv('VITE_API_BASE_URL', '')
+vi.stubEnv('VITE_API_BASE_URL', BASE)
 
 beforeAll(() => server.listen())
 afterEach(() => server.resetHandlers())


### PR DESCRIPTION
## Summary
- default API base URL to gateway port 8080
- update tests to exercise gateway-based calls

## Testing
- `npm ci`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890d8b97ca083298e93e5333dbd7470