### PR TITLE
Refactor analyzer to consume snapshot from analyze API

### DIFF
--- a/interface/src/App.test.tsx
+++ b/interface/src/App.test.tsx
@@ -36,9 +36,8 @@ test('shows loading spinner and displays result', async () => {
       const body = await request.json()
       expect(body).toEqual({ url: 'https://example.com', headless: false, force: false, domains: [] })
       await new Promise((r) => setTimeout(r, 1000))
-      return Response.json(full)
+      return Response.json({ ...full, snapshot: snap })
     }),
-    http.get('/analyze', async () => Response.json({ snapshot: snap })),
   )
   render(
     <DomainProvider>
@@ -100,9 +99,8 @@ test('shows degraded banner when martech is null', async () => {
     http.post('/analyze', async ({ request }) => {
       const body = await request.json()
       expect(body).toEqual({ url: 'https://partial.com', headless: false, force: false, domains: [] })
-      return Response.json(partial)
+      return Response.json({ ...partial, snapshot: snap })
     }),
-    http.get('/analyze', async () => Response.json({ snapshot: snap })),
   )
   render(
     <DomainProvider>

--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { test, expect } from 'vitest'
-import type { AnalyzeResult, Snapshot } from './AnalyzerCard'
+import type { AnalyzeResult } from './AnalyzerCard'
 import { computeMartechCount } from './AnalyzerCard'
 
 test('shows spinner when loading', async () => {
@@ -10,7 +10,7 @@ test('shows spinner when loading', async () => {
       id="a"
       url="foo"
       setUrl={() => {}}
-      onAnalyze={() => {}}
+      onAnalyze={async () => null}
       headless={false}
       setHeadless={() => {}}
       force={false}
@@ -18,7 +18,6 @@ test('shows spinner when loading', async () => {
       loading={true}
       error=""
       result={null}
-      snapshot={null}
     />,
   )
   expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
@@ -31,7 +30,7 @@ test('displays error message', async () => {
       id="a"
       url="foo"
       setUrl={() => {}}
-      onAnalyze={() => {}}
+      onAnalyze={async () => null}
       headless={false}
       setHeadless={() => {}}
       force={false}
@@ -39,7 +38,6 @@ test('displays error message', async () => {
       loading={false}
       error="oops"
       result={null}
-      snapshot={null}
     />,
   )
   expect(screen.getByText('oops')).toBeInTheDocument()
@@ -64,7 +62,7 @@ test('renders result lists', async () => {
       id="a"
       url="foo"
       setUrl={() => {}}
-      onAnalyze={() => {}}
+      onAnalyze={async () => null}
       headless={false}
       setHeadless={() => {}}
       force={false}
@@ -72,7 +70,6 @@ test('renders result lists', async () => {
       loading={false}
       error=""
       result={result}
-      snapshot={null}
     />,
   )
   expect(
@@ -90,7 +87,7 @@ test('shows degraded banner', async () => {
       id="a"
       url="foo"
       setUrl={() => {}}
-      onAnalyze={() => {}}
+      onAnalyze={async () => null}
       headless={false}
       setHeadless={() => {}}
       force={false}
@@ -98,38 +95,9 @@ test('shows degraded banner', async () => {
       loading={false}
       error=""
       result={{ ...result, degraded: true }}
-      snapshot={null}
     />,
   )
   expect(screen.getByText(/partial results/i)).toBeInTheDocument()
-})
-
-test('renders snapshot when provided', async () => {
-  const { default: AnalyzerCard } = await import('./AnalyzerCard')
-  const snap: Snapshot = {
-    profile: { name: 'Acme' },
-    digitalScore: 75,
-    stackDelta: [],
-    growthTriggers: [],
-    nextActions: [],
-  }
-  render(
-    <AnalyzerCard
-      id="a"
-      url="foo"
-      setUrl={() => {}}
-      onAnalyze={() => {}}
-      headless={false}
-      setHeadless={() => {}}
-      force={false}
-      setForce={() => {}}
-      loading={false}
-      error=""
-      result={result}
-      snapshot={snap}
-    />,
-  )
-  expect(screen.getByText('Acme')).toBeInTheDocument()
 })
 
 test('counts nested martech buckets correctly', () => {

--- a/interface/src/components/index.ts
+++ b/interface/src/components/index.ts
@@ -14,10 +14,6 @@ export { default as ErrorBoundary } from './ErrorBoundary'
 export { default as FeatureIcon } from './FeatureIcon'
 export { default as PropertyResults } from './PropertyResults'
 export { default as MartechResults } from './MartechResults'
-export {
-  default as InsightMarkdown,
-  type InsightMarkdownProps,
-} from './InsightMarkdown'
 export { default as MartechCategorySelector } from './MartechCategorySelector'
 
 export * from './summary'

--- a/interface/src/setupTests.ts
+++ b/interface/src/setupTests.ts
@@ -13,10 +13,14 @@ export const server = setupServer(
         notes: ['all good'],
       },
       martech: { core: ['GTM'] },
+      snapshot: {
+        profile: { name: 'Example' },
+        digitalScore: 50,
+        stackDelta: [],
+        growthTriggers: [],
+        nextActions: [],
+      },
     }),
-  ),
-  http.post('/insight', () =>
-    Response.json({ markdown: 'Test insight', degraded: false }),
   ),
 )
 


### PR DESCRIPTION
## Summary
- wire AnalyzerCard to store snapshot from /analyze and render ExecutiveSummaryCard
- switch App onAnalyze to POST /analyze returning snapshot alongside results
- drop legacy InsightMarkdown export and cleanup tests

## Testing
- `pytest -q`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892ca3bf25483298c6a31501ec7644f