### PR TITLE
Handle missing data in ExecutiveSummaryCard

### DIFF
--- a/interface/src/components/summary/ExecutiveSummaryCard.test.tsx
+++ b/interface/src/components/summary/ExecutiveSummaryCard.test.tsx
@@ -26,3 +26,30 @@ test('renders executive summary snapshot', () => {
   )
   expect(asFragment()).toMatchSnapshot()
 })
+
+test('omits sections when data is missing', () => {
+  const {
+    asFragment,
+    queryByLabelText,
+    queryAllByTestId,
+    container,
+  } = render(
+    <ExecutiveSummaryCard
+      profile={{
+        name: 'Acme Inc',
+        industry: 'SaaS',
+        location: 'NYC',
+        website: 'https://acme.com',
+      }}
+      score={75}
+      stack={[]}
+      triggers={[]}
+      actions={[]}
+    />,
+  )
+  expect(queryByLabelText('healthchecks')).toBeNull()
+  expect(container.querySelector('.xs\\:col-span-2.space-y-1')).toBeNull()
+  expect(queryAllByTestId('growth-trigger')).toHaveLength(0)
+  expect(container.querySelector('ul.flex.flex-wrap.gap-2')).toBeNull()
+  expect(asFragment()).toMatchSnapshot()
+})

--- a/interface/src/components/summary/ExecutiveSummaryCard.tsx
+++ b/interface/src/components/summary/ExecutiveSummaryCard.tsx
@@ -32,18 +32,24 @@ export default function ExecutiveSummaryCard({
           <CompanyProfileCard {...profile} />
         </div>
         <DigitalScoreBar score={score} />
-        <MiniRiskMatrix position={risk} />
-        <div className="xs:col-span-2 space-y-1">
-          {stack.map((s) => (
-            <StackDeltaRow key={s.label} {...s} />
-          ))}
-        </div>
-        <div className="xs:col-span-2">
-          <GrowthTriggersList triggers={triggers} />
-        </div>
-        <div className="xs:col-span-2">
-          <NextActionsChips actions={actions} />
-        </div>
+        {risk && <MiniRiskMatrix position={risk} />}
+        {stack.length > 0 && (
+          <div className="xs:col-span-2 space-y-1">
+            {stack.map((s) => (
+              <StackDeltaRow key={s.label} {...s} />
+            ))}
+          </div>
+        )}
+        {triggers.length > 0 && (
+          <div className="xs:col-span-2">
+            <GrowthTriggersList triggers={triggers} />
+          </div>
+        )}
+        {actions.length > 0 && (
+          <div className="xs:col-span-2">
+            <NextActionsChips actions={actions} />
+          </div>
+        )}
       </article>
     </section>
   )

--- a/interface/src/components/summary/__snapshots__/ExecutiveSummaryCard.test.tsx.snap
+++ b/interface/src/components/summary/__snapshots__/ExecutiveSummaryCard.test.tsx.snap
@@ -1,5 +1,70 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`omits sections when data is missing 1`] = `
+<DocumentFragment>
+  <section
+    aria-labelledby="exec-summary-heading"
+  >
+    <h2
+      class="sr-only"
+      id="exec-summary-heading"
+    >
+      Executive Summary
+    </h2>
+    <article
+      class="grid grid-cols-1 xs:grid-cols-2 gap-4 p-4 bg-white rounded shadow max-h-[320px] overflow-auto"
+    >
+      <div
+        class="xs:col-span-2"
+      >
+        <div
+          class="flex items-center gap-4 p-4 border rounded bg-white"
+        >
+          <div
+            class="text-sm"
+          >
+            <div
+              class="font-medium"
+            >
+              Acme Inc
+            </div>
+            <div>
+              SaaS
+            </div>
+            <div>
+              NYC
+            </div>
+            <a
+              class="text-blue-600 underline break-all"
+              href="https://acme.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://acme.com
+            </a>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div
+          class="text-sm mb-1"
+        >
+          Digital Score: 75
+        </div>
+        <div
+          class="h-2 bg-gray-200 rounded"
+        >
+          <div
+            class="h-full rounded"
+            style="width: 75%; background-color: rgb(230, 159, 0);"
+          />
+        </div>
+      </div>
+    </article>
+  </section>
+</DocumentFragment>
+`;
+
 exports[`renders executive summary snapshot 1`] = `
 <DocumentFragment>
   <section


### PR DESCRIPTION
## Summary
- Render MiniRiskMatrix only when risk data exists
- Skip stack, growth triggers, and action sections when their arrays are empty
- Add tests covering missing data scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689374315cc4832983beb4fbdfc472ba