### PR TITLE
Refactor snapshot serialization for gateway

### DIFF
--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -191,21 +191,40 @@ def build_snapshot(
     else:
         dns_risk = "low"
 
-    risk_matrix = {"dns": dns_risk}
+    coord_map = {
+        "low": {"x": 0, "y": 2},
+        "medium": {"x": 1, "y": 1},
+        "high": {"x": 2, "y": 0},
+    }
+    risk_matrix = coord_map[dns_risk]
 
-    next_actions: list[str] = []
+    stack_delta = [{"label": vendor, "status": "added"} for vendor in martech_list]
+
+    next_actions: list[dict[str, str]] = []
     if dns_risk != "low" and domain:
-        next_actions.append(f"Investigate DNS records for {domain}")
+        next_actions.append(
+            {"label": f"Investigate DNS records for {domain}", "targetId": "property"}
+        )
     if martech_list:
-        next_actions.append(f"Review {martech_list[0]} usage")
+        next_actions.append(
+            {
+                "label": f"Review {martech_list[0]} usage",
+                "targetId": "martech",
+            }
+        )
     else:
-        next_actions.append("Consider adding analytics tooling")
+        next_actions.append(
+            {
+                "label": "Consider adding analytics tooling",
+                "targetId": "martech",
+            }
+        )
 
     return {
         "profile": profile,
         "digitalScore": digital_score,
         "riskMatrix": risk_matrix,
-        "stackDelta": martech_list,
+        "stackDelta": stack_delta,
         "growthTriggers": notes,
         "nextActions": next_actions,
     }

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -140,10 +140,12 @@ def test_analyze_builds_snapshot(monkeypatch):
     assert snapshot["profile"]["name"] == "example.com"
     assert snapshot["profile"]["website"] == "https://example.com"
     assert snapshot["digitalScore"] > 0
-    assert snapshot["riskMatrix"]
-    assert snapshot["stackDelta"]
+    assert snapshot["riskMatrix"]["x"] == 0
+    assert snapshot["stackDelta"][0]["label"] == "GA"
+    assert snapshot["stackDelta"][0]["status"] == "added"
     assert snapshot["growthTriggers"]
-    assert snapshot["nextActions"]
+    assert snapshot["nextActions"][0]["label"] == "Review GA usage"
+    assert snapshot["nextActions"][0]["targetId"] == "martech"
 
 
 def test_analyze_failure_increments_metrics(monkeypatch):


### PR DESCRIPTION
## Summary
- model stackDelta as structured objects with label/status
- map DNS risk to matrix coordinates and structure nextActions with targetId
- expand gateway snapshot test to verify new fields

## Testing
- `pre-commit run --files services/gateway/app.py tests/test_gateway.py`
- `pytest tests/test_gateway.py -k test_analyze_builds_snapshot -q`
- manual POST `/analyze` with mocked services

------
https://chatgpt.com/codex/tasks/task_e_68938ca83d24832984f349c227229e42