### PR TITLE
Enrich snapshot profile and expose risk coordinates

### DIFF
--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -43,6 +43,7 @@ export type AnalyzeResult = {
 export type Snapshot = {
   profile: ExecutiveSummaryCardProps['profile']
   digitalScore: number
+  risk?: ExecutiveSummaryCardProps['risk']
   riskMatrix?: ExecutiveSummaryCardProps['risk']
   stackDelta: ExecutiveSummaryCardProps['stack']
   growthTriggers: string[]
@@ -114,7 +115,7 @@ export default function AnalyzerCard({
       ? {
           profile: snapshot.profile,
           score: snapshot.digitalScore,
-          risk: snapshot.riskMatrix,
+          risk: snapshot.risk ?? snapshot.riskMatrix,
           stack: snapshot.stackDelta,
           triggers:
             snapshot.growthTriggers.length > 0

--- a/interface/src/pages/AnalysisResultPage.tsx
+++ b/interface/src/pages/AnalysisResultPage.tsx
@@ -5,6 +5,7 @@ import { apiFetch } from '../api'
 type Snapshot = {
   profile: ExecutiveSummaryCardProps['profile']
   digitalScore: number
+  risk?: ExecutiveSummaryCardProps['risk']
   riskMatrix?: ExecutiveSummaryCardProps['risk']
   stackDelta: ExecutiveSummaryCardProps['stack']
   growthTriggers: string[]
@@ -32,7 +33,7 @@ export default function AnalysisResultPage() {
       <ExecutiveSummaryCard
         profile={snapshot.profile}
         score={snapshot.digitalScore}
-        risk={snapshot.riskMatrix}
+        risk={snapshot.risk ?? snapshot.riskMatrix}
         stack={snapshot.stackDelta}
         triggers={triggers}
         actions={snapshot.nextActions}

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -127,6 +127,9 @@ def test_analyze_builds_snapshot(monkeypatch):
                     "domains": ["example.com"],
                     "confidence": 0.9,
                     "notes": ["example note"],
+                    "industry": "SaaS",
+                    "location": "New York, NY",
+                    "logoUrl": "https://logo.example.com/logo.png",
                 },
             )
         return httpx.Response(404)
@@ -139,8 +142,12 @@ def test_analyze_builds_snapshot(monkeypatch):
     snapshot = r.json()["snapshot"]
     assert snapshot["profile"]["name"] == "example.com"
     assert snapshot["profile"]["website"] == "https://example.com"
+    assert snapshot["profile"]["industry"] == "SaaS"
+    assert snapshot["profile"]["location"] == "New York, NY"
+    assert snapshot["profile"]["logoUrl"] == "https://logo.example.com/logo.png"
     assert snapshot["digitalScore"] > 0
-    assert snapshot["riskMatrix"]["x"] == 0
+    assert snapshot["risk"]["x"] == 0
+    assert snapshot["risk"]["y"] == 1
     assert snapshot["stackDelta"][0]["label"] == "GA"
     assert snapshot["stackDelta"][0]["status"] == "added"
     assert snapshot["growthTriggers"]


### PR DESCRIPTION
## Summary
- include industry, location and logo URL in gateway snapshot profile
- compute risk coordinates from domain confidence and martech presence
- pass snapshot risk/profile directly to ExecutiveSummaryCard

## Testing
- `pytest -q`
- `npm test`
- `python - <<'PY'
import httpx
from fastapi.testclient import TestClient
from services.gateway import app as gateway_app

async def handler(request: httpx.Request) -> httpx.Response:
    if "martech" in str(request.url):
        return httpx.Response(200, json={"core": ["GA", "Segment"]})
    if "property" in str(request.url):
        return httpx.Response(200, json={
            "domains": ["example.com"],
            "confidence": 0.9,
            "notes": ["example note"],
            "industry": "SaaS",
            "location": "New York, NY",
            "logoUrl": "https://logo.example.com/logo.png",
        })
    return httpx.Response(404)

transport = httpx.MockTransport(handler)
class DummyClient(httpx.AsyncClient):
    def __init__(self):
        super().__init__(transport=transport)
    async def post(self, url, *args, **kwargs):
        return await super().post(url, *args, **kwargs)
    async def get(self, url, *args, **kwargs):
        return await super().get(url, *args, **kwargs)

gateway_app.httpx.AsyncClient = DummyClient
gateway_app.app.state.client = DummyClient()

client = TestClient(gateway_app.app)
resp = client.post("/analyze", json={"url":"https://example.com"})
print(resp.json())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68939e8c1ffc83298fbb91d3482268aa