### PR TITLE
Cap digital score and simplify risk snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ curl -sS -X POST http://localhost:8080/analyze \
 #   "snapshot": {
 #     "profile": {},
 #     "digitalScore": {},
-#     "riskMatrix": {},
+#     "risk": {},
 #     "stackDelta": {},
 #     "growthTriggers": {},
 #     "nextActions": {}

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -12,7 +12,7 @@ assessment and suggested next actions.
 {
   "profile": {},
   "digitalScore": {},
-  "riskMatrix": {},
+  "risk": {},
   "stackDelta": {},
   "growthTriggers": {},
   "nextActions": {}

--- a/interface/src/App.test.tsx
+++ b/interface/src/App.test.tsx
@@ -27,6 +27,7 @@ test('shows loading spinner and displays result', async () => {
   const snap: Snapshot = {
     profile: { name: 'Example' },
     digitalScore: 50,
+    risk: { x: 0, y: 0 },
     stackDelta: [],
     growthTriggers: [],
     nextActions: [],
@@ -92,6 +93,7 @@ test('shows degraded banner when martech is null', async () => {
   const snap: Snapshot = {
     profile: { name: 'Partial' },
     digitalScore: 40,
+    risk: { x: 0, y: 0 },
     stackDelta: [],
     growthTriggers: [],
     nextActions: [],

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -108,7 +108,7 @@ export default function AnalyzerCard({
       ? {
           profile: snapshot.profile,
           score: snapshot.digitalScore,
-          risk: snapshot.risk ?? snapshot.riskMatrix,
+          risk: snapshot.risk,
           stack: snapshot.stackDelta,
           triggers: snapshot.growthTriggers,
           actions: snapshot.nextActions,

--- a/interface/src/pages/AnalysisResultPage.tsx
+++ b/interface/src/pages/AnalysisResultPage.tsx
@@ -29,7 +29,7 @@ export default function AnalysisResultPage() {
       <ExecutiveSummaryCard
         profile={snapshot.profile}
         score={snapshot.digitalScore}
-        risk={snapshot.risk ?? snapshot.riskMatrix}
+        risk={snapshot.risk}
         stack={snapshot.stackDelta}
         triggers={triggers}
         actions={snapshot.nextActions}

--- a/interface/src/setupTests.ts
+++ b/interface/src/setupTests.ts
@@ -16,6 +16,7 @@ export const server = setupServer(
       snapshot: {
         profile: { name: 'Example' },
         digitalScore: 50,
+        risk: { x: 0, y: 0 },
         stackDelta: [],
         growthTriggers: [],
         nextActions: [],

--- a/interface/src/types/snapshot.ts
+++ b/interface/src/types/snapshot.ts
@@ -3,8 +3,7 @@ import type { ExecutiveSummaryCardProps } from '../components/summary'
 export interface Snapshot {
   profile: ExecutiveSummaryCardProps['profile']
   digitalScore: number
-  risk?: ExecutiveSummaryCardProps['risk']
-  riskMatrix?: ExecutiveSummaryCardProps['risk']
+  risk: ExecutiveSummaryCardProps['risk']
   stackDelta: ExecutiveSummaryCardProps['stack']
   growthTriggers: string[]
   nextActions: ExecutiveSummaryCardProps['actions']

--- a/services/analyze/buildSnapshot.ts
+++ b/services/analyze/buildSnapshot.ts
@@ -8,7 +8,7 @@
 export interface Snapshot {
   profile: unknown;
   digitalScore: unknown;
-  riskMatrix: unknown;
+  risk: unknown;
   stackDelta: unknown;
   growthTriggers: unknown;
   nextActions: unknown;
@@ -17,7 +17,7 @@ export interface Snapshot {
 export interface BuildSnapshotResult {
   profile: unknown;
   digitalScore: unknown;
-  riskMatrix: unknown;
+  risk: unknown;
   stackDelta: unknown;
   growthTriggers: unknown;
   nextActions: unknown;
@@ -27,7 +27,7 @@ export function buildSnapshot(result: BuildSnapshotResult): Snapshot {
   const {
     profile,
     digitalScore,
-    riskMatrix,
+    risk,
     stackDelta,
     growthTriggers,
     nextActions,
@@ -36,7 +36,7 @@ export function buildSnapshot(result: BuildSnapshotResult): Snapshot {
   return {
     profile,
     digitalScore,
-    riskMatrix,
+    risk,
     stackDelta,
     growthTriggers,
     nextActions,

--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -199,7 +199,7 @@ def build_snapshot(
     if logo_url:
         profile["logoUrl"] = logo_url
 
-    digital_score = int(confidence * 100) + martech_count
+    digital_score = min(100, int(confidence * 100) + martech_count)
 
     # Derive risk coordinates from domain confidence and martech coverage.
     if confidence >= 0.8:
@@ -220,7 +220,6 @@ def build_snapshot(
         y = 0
 
     risk = {"x": x, "y": y}
-    risk_matrix = risk  # backwards compat
 
     stack_delta = [{"label": vendor, "status": "added"} for vendor in martech_list]
 
@@ -248,7 +247,6 @@ def build_snapshot(
         "profile": profile,
         "digitalScore": digital_score,
         "risk": risk,
-        "riskMatrix": risk_matrix,
         "stackDelta": stack_delta,
         "growthTriggers": notes,
         "nextActions": next_actions,


### PR DESCRIPTION
## Summary
- Cap gateway snapshot digital score at 100 and output a single `risk` field
- Drop redundant `riskMatrix` references across docs and services
- Align frontend snapshot types and usages with the new schema

## Testing
- `pytest`
- `npm --prefix interface test`


------
https://chatgpt.com/codex/tasks/task_e_6894d4f8c860832995365d69f835233a