### PR TITLE
Add risk level to snapshot and UI

### DIFF
--- a/interface/src/App.test.tsx
+++ b/interface/src/App.test.tsx
@@ -27,7 +27,7 @@ test('shows loading spinner and displays result', async () => {
   const snap: Snapshot = {
     profile: { name: 'Example' },
     digitalScore: 50,
-    risk: { x: 0, y: 0 },
+    risk: { x: 0, y: 0, level: 'low' },
     stackDelta: [],
     growthTriggers: [],
     nextActions: [],
@@ -93,7 +93,7 @@ test('shows degraded banner when martech is null', async () => {
   const snap: Snapshot = {
     profile: { name: 'Partial' },
     digitalScore: 40,
-    risk: { x: 0, y: 0 },
+    risk: { x: 0, y: 0, level: 'low' },
     stackDelta: [],
     growthTriggers: [],
     nextActions: [],

--- a/interface/src/components/summary/ExecutiveSummaryCard.test.tsx
+++ b/interface/src/components/summary/ExecutiveSummaryCard.test.tsx
@@ -12,7 +12,7 @@ test('renders executive summary snapshot', () => {
         website: 'https://acme.com',
       }}
       score={75}
-      risk={{ x: 1, y: 2 }}
+      risk={{ x: 1, y: 2, level: 'high' }}
       stack={[
         { label: 'React', status: 'added' },
         { label: 'Vue', status: 'removed' },

--- a/interface/src/components/summary/ExecutiveSummaryCard.tsx
+++ b/interface/src/components/summary/ExecutiveSummaryCard.tsx
@@ -1,6 +1,6 @@
 import CompanyProfileCard, { type CompanyProfileProps } from './CompanyProfileCard'
 import DigitalScoreBar from './DigitalScoreBar'
-import MiniRiskMatrix, { type MiniRiskMatrixProps } from './MiniRiskMatrix'
+import MiniRiskMatrix, { type RiskLevel } from './MiniRiskMatrix'
 import StackDeltaRow, { type StackDeltaRowProps } from './StackDeltaRow'
 import GrowthTriggersList, { type GrowthTriggersListProps } from './GrowthTriggersList'
 import NextActionsChips, { type NextActionsChipsProps } from './NextActionsChips'
@@ -8,7 +8,7 @@ import NextActionsChips, { type NextActionsChipsProps } from './NextActionsChips
 export interface ExecutiveSummaryCardProps {
   profile: CompanyProfileProps
   score: number
-  risk?: MiniRiskMatrixProps['position']
+  risk?: { x: number; y: number; level: RiskLevel }
   stack: StackDeltaRowProps[]
   triggers: GrowthTriggersListProps['triggers']
   actions: NextActionsChipsProps['actions']
@@ -32,7 +32,9 @@ export default function ExecutiveSummaryCard({
           <CompanyProfileCard {...profile} />
         </div>
         <DigitalScoreBar score={score} />
-        {risk && <MiniRiskMatrix position={risk} />}
+        {risk && (
+          <MiniRiskMatrix position={{ x: risk.x, y: risk.y }} level={risk.level} />
+        )}
         {stack.length > 0 && (
           <div className="xs:col-span-2 space-y-1">
             {stack.map((s) => (

--- a/interface/src/components/summary/MiniRiskMatrix.tsx
+++ b/interface/src/components/summary/MiniRiskMatrix.tsx
@@ -1,16 +1,26 @@
 import type { JSX } from 'react'
 import { COLOR_BLIND_PALETTE } from './palette'
 
+export type RiskLevel = 'low' | 'medium' | 'high'
+
 export interface MiniRiskMatrixProps {
   position?: { x: number; y: number }
+  level?: RiskLevel
   onClick?: () => void
 }
 
-export default function MiniRiskMatrix({ position, onClick }: MiniRiskMatrixProps) {
+export default function MiniRiskMatrix({ position, level = 'high', onClick }: MiniRiskMatrixProps) {
   function handleClick() {
     if (onClick) onClick()
     else document.getElementById('healthchecks')?.scrollIntoView({ behavior: 'smooth' })
   }
+  const colorMap: Record<RiskLevel, string> = {
+    low: COLOR_BLIND_PALETTE.green,
+    medium: COLOR_BLIND_PALETTE.amber,
+    high: COLOR_BLIND_PALETTE.red,
+  }
+  const activeColor = colorMap[level]
+
   const cells: JSX.Element[] = []
   for (let y = 0; y < 3; y++) {
     for (let x = 0; x < 3; x++) {
@@ -20,9 +30,7 @@ export default function MiniRiskMatrix({ position, onClick }: MiniRiskMatrixProp
           key={`${x}-${y}`}
           className="w-3 h-3 border"
           style={{
-            backgroundColor: active
-              ? COLOR_BLIND_PALETTE.red
-              : '#f3f4f6',
+            backgroundColor: active ? activeColor : '#f3f4f6',
           }}
         />
       )

--- a/interface/src/components/summary/index.ts
+++ b/interface/src/components/summary/index.ts
@@ -9,6 +9,7 @@ export {
 export {
   default as MiniRiskMatrix,
   type MiniRiskMatrixProps,
+  type RiskLevel,
 } from './MiniRiskMatrix'
 export {
   default as StackDeltaRow,

--- a/interface/src/setupTests.ts
+++ b/interface/src/setupTests.ts
@@ -16,7 +16,7 @@ export const server = setupServer(
       snapshot: {
         profile: { name: 'Example' },
         digitalScore: 50,
-        risk: { x: 0, y: 0 },
+        risk: { x: 0, y: 0, level: 'low' },
         stackDelta: [],
         growthTriggers: [],
         nextActions: [],

--- a/interface/src/types/snapshot.ts
+++ b/interface/src/types/snapshot.ts
@@ -3,7 +3,7 @@ import type { ExecutiveSummaryCardProps } from '../components/summary'
 export interface Snapshot {
   profile: ExecutiveSummaryCardProps['profile']
   digitalScore: number
-  risk: ExecutiveSummaryCardProps['risk']
+  risk: NonNullable<ExecutiveSummaryCardProps['risk']>
   stackDelta: ExecutiveSummaryCardProps['stack']
   growthTriggers: string[]
   nextActions: ExecutiveSummaryCardProps['actions']

--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -179,7 +179,9 @@ def build_snapshot(
             domain = domain_list[0]
         confidence = float(property_data.get("confidence", 0.0) or 0.0)
         notes = property_data.get("notes", []) or []
-        industry = property_data.get("industry", "") or property_data.get("category", "")
+        industry = property_data.get("industry", "") or property_data.get(
+            "category", ""
+        )
         location = property_data.get("location", "") or property_data.get("country", "")
         logo_url = (
             property_data.get("logoUrl")
@@ -223,7 +225,8 @@ def build_snapshot(
     else:
         y = 0
 
-    risk = {"x": x, "y": y}
+    level = ["low", "medium", "high"][max(x, y)]
+    risk = {"x": x, "y": y, "level": level}
 
     stack_delta = [{"label": vendor, "status": "added"} for vendor in martech_list]
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -149,6 +149,7 @@ def test_analyze_builds_snapshot(monkeypatch):
     assert snapshot["digitalScore"] == expected_score
     assert snapshot["risk"]["x"] == 0
     assert snapshot["risk"]["y"] == 1
+    assert snapshot["risk"]["level"] == "medium"
     assert snapshot["stackDelta"][0]["label"] == "GA"
     assert snapshot["stackDelta"][0]["status"] == "added"
     assert snapshot["growthTriggers"]


### PR DESCRIPTION
## Summary
- include overall risk `level` in gateway snapshot output
- color risk matrix cell by `level` and pass through summary components
- extend snapshot typings and tests for new risk level

## Testing
- `pre-commit run --files services/gateway/app.py tests/test_gateway.py`
- `pytest`
- `cd interface && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f81c410083298b94860be68f9fb6