### PR TITLE
feat: surface growth triggers from property analysis

### DIFF
--- a/interface/src/components/summary/ExecutiveSummaryCard.tsx
+++ b/interface/src/components/summary/ExecutiveSummaryCard.tsx
@@ -6,14 +6,14 @@ export interface ExecutiveSummaryCardProps {
   profile: CompanyProfileProps
   score: number
   vendors: string[]
-  triggers: GrowthTriggersListProps['triggers']
+  triggers?: GrowthTriggersListProps['triggers']
 }
 
 export default function ExecutiveSummaryCard({
   profile,
   score,
   vendors,
-  triggers,
+  triggers = [],
 }: ExecutiveSummaryCardProps) {
   return (
     <section aria-labelledby="exec-summary-heading">

--- a/interface/src/pages/AnalysisResultPage.tsx
+++ b/interface/src/pages/AnalysisResultPage.tsx
@@ -20,17 +20,13 @@ export default function AnalysisResultPage() {
   }, [])
 
   if (!snapshot) return null
-
-  const triggers =
-    snapshot.growthTriggers.length > 0 ? snapshot.growthTriggers : ['—']
-
   return (
     <div className="p-4">
       <ExecutiveSummaryCard
         profile={snapshot.profile}
         score={snapshot.digitalScore}
         vendors={snapshot.vendors}
-        triggers={triggers}
+        triggers={snapshot.growthTriggers}
       />
     </div>
   )

--- a/services/gateway/app.py
+++ b/services/gateway/app.py
@@ -169,7 +169,7 @@ def build_snapshot(
 
     domain = ""
     confidence = 0.0
-    notes: list[str] = []
+    growth_triggers: list[str] = []
     industry = ""
     location = ""
     logo_url = ""
@@ -178,7 +178,7 @@ def build_snapshot(
         if domain_list:
             domain = domain_list[0]
         confidence = float(property_data.get("confidence", 0.0) or 0.0)
-        notes = property_data.get("notes", []) or []
+        growth_triggers = property_data.get("notes") or []
         enrichment = property_data.get("enrichment") or {}
         industry = (
             property_data.get("industry")
@@ -222,7 +222,7 @@ def build_snapshot(
         "profile": profile,
         "digitalScore": digital_score,
         "vendors": vendors,
-        "growthTriggers": notes,
+        "growthTriggers": growth_triggers or [],
     }
 
 

--- a/services/property/app.py
+++ b/services/property/app.py
@@ -90,6 +90,9 @@ async def analyze(req: RawAnalyzeRequest) -> JSONResponse:
         else:
             notes.append(f"{host} did not resolve")
 
+    actionable = [n for n in notes if "resolve" not in n.lower()]
+    actionable = actionable[:3]
+
     confidence = len(resolved) / len(results)
 
     industry = ""
@@ -114,13 +117,14 @@ async def analyze(req: RawAnalyzeRequest) -> JSONResponse:
         except Exception:  # noqa: BLE001
             pass
 
-    return JSONResponse(
-        {
-            "domains": resolved,
-            "confidence": round(confidence, 2),
-            "notes": notes,
-            "industry": industry,
-            "location": location,
-            "logoUrl": logo_url,
-        }
-    )
+    payload = {
+        "domains": resolved,
+        "confidence": round(confidence, 2),
+        "industry": industry,
+        "location": location,
+        "logoUrl": logo_url,
+    }
+    if actionable:
+        payload["notes"] = actionable
+
+    return JSONResponse(payload)


### PR DESCRIPTION
## Summary
- filter out DNS-only notes and expose up to three actionable growth triggers
- forward growth triggers through gateway snapshot
- show Growth Triggers section only when data exists

## Testing
- `pytest -q`
- `(cd interface && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_689515c501a08329ae2bc8a4c416fb92