### PR TITLE
feat: add Aeris dashboard and UI building blocks

### DIFF
--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -3,6 +3,7 @@ import PropertyResults from './PropertyResults'
 import MartechCategorySelector, {
   type MartechItem,
 } from './MartechCategorySelector'
+import AerisDashboard from './aeris/AerisDashboard'
 import {
   ExecutiveSummaryCard,
   type ExecutiveSummaryCardProps,
@@ -110,8 +111,6 @@ export default function AnalyzerCard({
 
   if (result) {
     const { property, martech, degraded } = result
-    const domainCount = property?.domains.length || 0
-    const martechCount = computeMartechCount(martech)
     const snapshotForCard: ExecutiveSummaryCardProps | null = snapshot
       ? {
           profile: snapshot.profile,
@@ -150,39 +149,6 @@ export default function AnalyzerCard({
             )}
           </ul>
         </nav>
-        <div className="grid grid-cols-2 gap-4 mb-4" role="region" aria-label="Key metrics">
-          {aeris ? (
-            <>
-              <div className="p-3 rounded bg-gray-800 text-white text-center">
-                <div className="text-lg font-semibold">
-                  {Math.round(aeris.core_score)}
-                </div>
-                <div className="text-xs">AERIS Score</div>
-              </div>
-              <div className="p-3 rounded bg-gray-800 text-white text-center">
-                <div className="text-lg font-semibold">{martechCount}</div>
-                <div className="text-xs">Martech Vendors</div>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="p-3 rounded bg-gray-800 text-white text-center">
-                <div className="text-lg font-semibold">{domainCount}</div>
-                <div className="text-xs">Domains</div>
-              </div>
-              <div className="p-3 rounded bg-gray-800 text-white text-center">
-                <div className="text-lg font-semibold">
-                  {Math.round((property?.confidence || 0) * 100)}%
-                </div>
-                <div className="text-xs">Confidence</div>
-              </div>
-              <div className="p-3 rounded bg-gray-800 text-white text-center">
-                <div className="text-lg font-semibold">{martechCount}</div>
-                <div className="text-xs">Martech Vendors</div>
-              </div>
-            </>
-          )}
-        </div>
         {degraded && (
           <div className="border border-yellow-500 bg-yellow-50 text-yellow-700 p-2 rounded mb-4 text-sm">
             Partial results shown due to degraded analysis.
@@ -191,6 +157,11 @@ export default function AnalyzerCard({
         {snapshotForCard && (
           <div className="mb-4">
             <ExecutiveSummaryCard {...snapshotForCard} />
+          </div>
+        )}
+        {aeris && (
+          <div className="mb-4">
+            <AerisDashboard data={aeris} />
           </div>
         )}
         {property && !aeris && (

--- a/interface/src/components/aeris/AerisDashboard.tsx
+++ b/interface/src/components/aeris/AerisDashboard.tsx
@@ -1,0 +1,134 @@
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
+import { Progress } from '../ui/progress'
+import type { AerisResponse } from '../../api'
+
+interface BreakdownItem {
+  name: string
+  score: number
+}
+interface PeerItem {
+  name: string
+  score: number
+}
+interface VariantItem {
+  name: string
+  score: number
+}
+
+export default function AerisDashboard({ data }: { data: AerisResponse }) {
+  const signals = (data.signal_breakdown as BreakdownItem[]) || []
+  const peers = (data.peers as PeerItem[]) || []
+  const variants = (data.variants as VariantItem[]) || []
+  const opportunities = (data.opportunities as string[]) || []
+  const narratives = (data.narratives as string[]) || []
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>AERIS Score</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-4xl font-bold">{Math.round(data.core_score)}</div>
+        </CardContent>
+      </Card>
+
+      {peers.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Peer Benchmark</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Peer</TableHead>
+                  <TableHead className="text-right">Score</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {peers.map((p) => (
+                  <TableRow key={p.name}>
+                    <TableCell>{p.name}</TableCell>
+                    <TableCell className="text-right">{p.score}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      {signals.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Signals</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {signals.map((s) => (
+              <div key={s.name}>
+                <div className="flex justify-between text-sm mb-1">
+                  <span>{s.name}</span>
+                  <span>{s.score}</span>
+                </div>
+                <Progress value={s.score} max={100} />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {variants.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Variants</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-end h-32 gap-2">
+              {variants.map((v) => (
+                <div key={v.name} className="flex-1">
+                  <div
+                    className="bg-primary w-full rounded-t"
+                    style={{ height: `${v.score}%` }}
+                  />
+                  <div className="text-xs text-center mt-1">{v.name}</div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {opportunities.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Opportunities</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="list-disc pl-5 space-y-1 text-sm">
+              {opportunities.map((o, i) => (
+                <li key={i}>{o}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      {narratives.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Narratives</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="list-disc pl-5 space-y-1 text-sm">
+              {narratives.map((n, i) => (
+                <li key={i}>{n}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/interface/src/components/index.ts
+++ b/interface/src/components/index.ts
@@ -15,5 +15,6 @@ export { default as FeatureIcon } from './FeatureIcon'
 export { default as PropertyResults } from './PropertyResults'
 export { default as MartechResults } from './MartechResults'
 export { default as MartechCategorySelector } from './MartechCategorySelector'
+export { default as AerisDashboard } from './aeris/AerisDashboard'
 
 export * from './summary'

--- a/interface/src/components/ui/progress.tsx
+++ b/interface/src/components/ui/progress.tsx
@@ -1,0 +1,16 @@
+import type { HTMLAttributes } from 'react'
+import clsx from 'clsx'
+
+export interface ProgressProps extends HTMLAttributes<HTMLDivElement> {
+  value?: number
+  max?: number
+}
+
+export function Progress({ className, value = 0, max = 100, ...props }: ProgressProps) {
+  const pct = Math.min(100, Math.max(0, (value / max) * 100))
+  return (
+    <div className={clsx('w-full bg-gray-200 rounded', className)} {...props}>
+      <div className="h-2 bg-primary rounded" style={{ width: `${pct}%` }} />
+    </div>
+  )
+}

--- a/interface/src/components/ui/table.tsx
+++ b/interface/src/components/ui/table.tsx
@@ -1,0 +1,44 @@
+import type {
+  HTMLAttributes,
+  TableHTMLAttributes,
+  ThHTMLAttributes,
+  TdHTMLAttributes,
+} from 'react'
+import clsx from 'clsx'
+
+export function Table({ className, ...props }: TableHTMLAttributes<HTMLTableElement>) {
+  return (
+    <div className="w-full overflow-auto">
+      <table className={clsx('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  )
+}
+
+export function TableHeader({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {
+  return <thead className={clsx('[&_tr]:border-b', className)} {...props} />
+}
+
+export function TableBody({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={clsx('bg-white', className)} {...props} />
+}
+
+export function TableRow({ className, ...props }: HTMLAttributes<HTMLTableRowElement>) {
+  return <tr className={clsx('border-b transition-colors', className)} {...props} />
+}
+
+export function TableHead({ className, ...props }: ThHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <th
+      className={clsx('h-10 px-2 text-left align-middle font-medium text-gray-600', className)}
+      {...props}
+    />
+  )
+}
+
+export function TableCell({ className, ...props }: TdHTMLAttributes<HTMLTableCellElement>) {
+  return <td className={clsx('p-2 align-middle', className)} {...props} />
+}
+
+export function TableCaption({ className, ...props }: HTMLAttributes<HTMLTableCaptionElement>) {
+  return <caption className={clsx('mt-2 text-sm text-gray-500', className)} {...props} />
+}


### PR DESCRIPTION
## Summary
- add reusable AerisDashboard component displaying score, peers, signals, variants, opportunities and narratives
- introduce lightweight Progress and Table components for consistent styling
- swap AnalyzerCard metric grid for AerisDashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689663cce5848329960d50f373286c01