### PR TITLE
test: add AERIS dashboard coverage

### DIFF
--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react'
-import { test, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+import { test, expect, vi } from 'vitest'
 import type { AnalyzeResult } from './AnalyzerCard'
 import { computeMartechCount } from './AnalyzerCard'
 
@@ -55,14 +56,50 @@ const result: AnalyzeResult = {
   degraded: false,
 }
 
-test('renders result lists', async () => {
+test('renders AERIS dashboard after analysis', async () => {
+  vi.mock('../api', () => ({
+    fetchAeris: vi.fn().mockResolvedValue({ core_score: 10, signal_breakdown: [] }),
+  }))
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
-  render(
+  const onAnalyze = vi.fn().mockResolvedValue({
+    profile: {
+      name: 'ex',
+      tagline: '',
+      industry: '',
+      location: '',
+      website: '',
+      logoUrl: '',
+    },
+    score: 0,
+    vendors: [],
+    triggers: [],
+    seo: {},
+  })
+  const { rerender } = render(
     <AnalyzerCard
       id="a"
       url="foo"
       setUrl={() => {}}
-      onAnalyze={async () => null}
+      onAnalyze={onAnalyze}
+      headless={false}
+      setHeadless={() => {}}
+      force={false}
+      setForce={() => {}}
+      loading={false}
+      error=""
+      result={null}
+    />,
+  )
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /analyze/i }))
+    await onAnalyze.mock.results[0].value
+  })
+  rerender(
+    <AnalyzerCard
+      id="a"
+      url="foo"
+      setUrl={() => {}}
+      onAnalyze={onAnalyze}
       headless={false}
       setHeadless={() => {}}
       force={false}
@@ -72,12 +109,7 @@ test('renders result lists', async () => {
       result={result}
     />,
   )
-  expect(
-    screen.getByRole('heading', { name: 'Confidence' })
-  ).toBeInTheDocument()
-  expect(
-    screen.getByRole('tab', { name: /Content Management System/i })
-  ).toBeInTheDocument()
+  expect(await screen.findByText('AERIS Score')).toBeInTheDocument()
 })
 
 test('shows degraded banner', async () => {

--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -58,7 +58,11 @@ const result: AnalyzeResult = {
 
 test('renders AERIS dashboard after analysis', async () => {
   vi.mock('../api', () => ({
-    fetchAeris: vi.fn().mockResolvedValue({ core_score: 10, signal_breakdown: [] }),
+    fetchAeris: vi.fn().mockResolvedValue({
+      core_score: 10,
+      signal_breakdown: [],
+      degraded: false,
+    }),
   }))
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   const onAnalyze = vi.fn().mockResolvedValue({

--- a/interface/src/components/aeris/AerisDashboard.test.tsx
+++ b/interface/src/components/aeris/AerisDashboard.test.tsx
@@ -12,6 +12,7 @@ const mockData = {
   variants: [{ name: 'V1', score: 30 }],
   opportunities: ['Opportunity 1'],
   narratives: ['Narrative 1'],
+  degraded: false,
 }
 
 test('renders AerisDashboard snapshot', () => {

--- a/interface/src/components/aeris/AerisDashboard.test.tsx
+++ b/interface/src/components/aeris/AerisDashboard.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react'
+import { test, expect } from 'vitest'
+import AerisDashboard from './AerisDashboard'
+
+const mockData = {
+  core_score: 42,
+  signal_breakdown: [
+    { name: 'Signal A', score: 80 },
+    { name: 'Signal B', score: 20 },
+  ],
+  peers: [{ name: 'Peer 1', score: 50 }],
+  variants: [{ name: 'V1', score: 30 }],
+  opportunities: ['Opportunity 1'],
+  narratives: ['Narrative 1'],
+}
+
+test('renders AerisDashboard snapshot', () => {
+  const { asFragment } = render(<AerisDashboard data={mockData} />)
+  expect(asFragment()).toMatchSnapshot()
+})

--- a/interface/src/components/aeris/__snapshots__/AerisDashboard.test.tsx.snap
+++ b/interface/src/components/aeris/__snapshots__/AerisDashboard.test.tsx.snap
@@ -1,0 +1,232 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renders AerisDashboard snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="space-y-4"
+  >
+    <div
+      class="rounded-lg border bg-white shadow-sm"
+    >
+      <div
+        class="p-4 border-b"
+      >
+        <h3
+          class="text-lg font-semibold"
+        >
+          AERIS Score
+        </h3>
+      </div>
+      <div
+        class="p-4"
+      >
+        <div
+          class="text-4xl font-bold"
+        >
+          42
+        </div>
+      </div>
+    </div>
+    <div
+      class="rounded-lg border bg-white shadow-sm"
+    >
+      <div
+        class="p-4 border-b"
+      >
+        <h3
+          class="text-lg font-semibold"
+        >
+          Peer Benchmark
+        </h3>
+      </div>
+      <div
+        class="p-4"
+      >
+        <div
+          class="w-full overflow-auto"
+        >
+          <table
+            class="w-full caption-bottom text-sm"
+          >
+            <thead
+              class="[&_tr]:border-b"
+            >
+              <tr
+                class="border-b transition-colors"
+              >
+                <th
+                  class="h-10 px-2 text-left align-middle font-medium text-gray-600"
+                >
+                  Peer
+                </th>
+                <th
+                  class="h-10 px-2 text-left align-middle font-medium text-gray-600 text-right"
+                >
+                  Score
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="bg-white"
+            >
+              <tr
+                class="border-b transition-colors"
+              >
+                <td
+                  class="p-2 align-middle"
+                >
+                  Peer 1
+                </td>
+                <td
+                  class="p-2 align-middle text-right"
+                >
+                  50
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div
+      class="rounded-lg border bg-white shadow-sm"
+    >
+      <div
+        class="p-4 border-b"
+      >
+        <h3
+          class="text-lg font-semibold"
+        >
+          Signals
+        </h3>
+      </div>
+      <div
+        class="p-4 space-y-2"
+      >
+        <div>
+          <div
+            class="flex justify-between text-sm mb-1"
+          >
+            <span>
+              Signal A
+            </span>
+            <span>
+              80
+            </span>
+          </div>
+          <div
+            class="w-full bg-gray-200 rounded"
+          >
+            <div
+              class="h-2 bg-primary rounded"
+              style="width: 80%;"
+            />
+          </div>
+        </div>
+        <div>
+          <div
+            class="flex justify-between text-sm mb-1"
+          >
+            <span>
+              Signal B
+            </span>
+            <span>
+              20
+            </span>
+          </div>
+          <div
+            class="w-full bg-gray-200 rounded"
+          >
+            <div
+              class="h-2 bg-primary rounded"
+              style="width: 20%;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="rounded-lg border bg-white shadow-sm"
+    >
+      <div
+        class="p-4 border-b"
+      >
+        <h3
+          class="text-lg font-semibold"
+        >
+          Variants
+        </h3>
+      </div>
+      <div
+        class="p-4"
+      >
+        <div
+          class="flex items-end h-32 gap-2"
+        >
+          <div
+            class="flex-1"
+          >
+            <div
+              class="bg-primary w-full rounded-t"
+              style="height: 30%;"
+            />
+            <div
+              class="text-xs text-center mt-1"
+            >
+              V1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="rounded-lg border bg-white shadow-sm"
+    >
+      <div
+        class="p-4 border-b"
+      >
+        <h3
+          class="text-lg font-semibold"
+        >
+          Opportunities
+        </h3>
+      </div>
+      <div
+        class="p-4"
+      >
+        <ul
+          class="list-disc pl-5 space-y-1 text-sm"
+        >
+          <li>
+            Opportunity 1
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div
+      class="rounded-lg border bg-white shadow-sm"
+    >
+      <div
+        class="p-4 border-b"
+      >
+        <h3
+          class="text-lg font-semibold"
+        >
+          Narratives
+        </h3>
+      </div>
+      <div
+        class="p-4"
+      >
+        <ul
+          class="list-disc pl-5 space-y-1 text-sm"
+        >
+          <li>
+            Narrative 1
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -554,3 +554,18 @@ def test_aeris_timeout(monkeypatch):
     r = client.post("/aeris", json={"url": "https://example.com"})
     assert r.status_code == 502
     assert recorded["timeout"] == 30
+
+
+def test_aeris_forwards_notes(monkeypatch):
+    captured = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(200, json={"core_score": 4, "signal_breakdown": []})
+
+    transport = httpx.MockTransport(handler)
+    _set_mock_transport(monkeypatch, transport)
+
+    r = client.post("/aeris", json={"url": "https://example.com", "notes": "hi"})
+    assert r.status_code == 200
+    assert captured["payload"]["notes"] == "hi"

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -145,6 +145,11 @@ def test_aeris_endpoint(monkeypatch):
     assert data["core_score"] == 1
 
 
+def test_aeris_invalid_request():
+    r = client.post("/aeris", json={})
+    assert r.status_code == 400
+
+
 def test_research_trim(monkeypatch):
     async def fake_report(prompt: str, **_kwargs):
         return {"markdown": "Trim me", "degraded": False}


### PR DESCRIPTION
## Summary
- adjust AnalyzerCard test to assert AERIS dashboard rendering
- snapshot-test AerisDashboard component with sample data
- add backend and gateway tests for `/aeris`

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689676b21d408329b3dc38729413d933