### PR TITLE
Propagate AERIS degraded flag

### DIFF
--- a/interface/src/components/aeris/AerisDashboard.test.tsx
+++ b/interface/src/components/aeris/AerisDashboard.test.tsx
@@ -19,3 +19,18 @@ test('renders AerisDashboard snapshot', () => {
   const { asFragment } = render(<AerisDashboard data={mockData} />)
   expect(asFragment()).toMatchSnapshot()
 })
+
+test('shows unavailable when degraded', () => {
+  const { getByText } = render(
+    <AerisDashboard data={{ ...mockData, degraded: true }} />
+  )
+  getByText('AERIS unavailable')
+})
+
+test('shows unavailable when core_score missing', () => {
+  const { core_score, ...rest } = mockData
+  const { getByText } = render(
+    <AerisDashboard data={{ ...rest } as any} />
+  )
+  getByText('AERIS unavailable')
+})

--- a/interface/src/components/aeris/AerisDashboard.tsx
+++ b/interface/src/components/aeris/AerisDashboard.tsx
@@ -14,6 +14,7 @@ export default function AerisDashboard({ data }: { data: AerisResponse }) {
   const variants: AerisVariantItem[] = data.variants ?? []
   const opportunities: string[] = data.opportunities ?? []
   const narratives: string[] = data.narratives ?? []
+  const unavailable = data.degraded || data.core_score == null
 
   return (
     <div className="space-y-4">
@@ -22,7 +23,9 @@ export default function AerisDashboard({ data }: { data: AerisResponse }) {
           <CardTitle>AERIS Score</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-4xl font-bold">{Math.round(data.core_score)}</div>
+          <div className="text-4xl font-bold">
+            {unavailable ? 'AERIS unavailable' : Math.round(data.core_score)}
+          </div>
         </CardContent>
       </Card>
 

--- a/tests/test_insight.py
+++ b/tests/test_insight.py
@@ -158,6 +158,19 @@ def test_aeris_missing_score(monkeypatch):
     assert r.json()["degraded"] is True
 
 
+def test_aeris_generation_failure(monkeypatch):
+    async def fake_call(messages, **_kwargs):  # noqa: ARG001
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        insight_mod.orchestrator, "call_openai_with_retry", fake_call, raising=False
+    )
+
+    r = client.post("/aeris", json={"url": "https://example.com"})
+    assert r.status_code == 502
+    assert r.json()["degraded"] is True
+
+
 def test_aeris_invalid_request():
     r = client.post("/aeris", json={})
     assert r.status_code == 400


### PR DESCRIPTION
## Summary
- mark AERIS responses degraded when generation fails and forward flag through gateway
- show "AERIS unavailable" when score is missing or degraded
- test AERIS degradation scenarios in services and UI

## Testing
- `pytest`
- `cd interface && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689698e13fa483299a1aad1d4729a750