### PR TITLE
Normalize analyzer URLs

### DIFF
--- a/interface/src/components/AnalyzerCard.test.tsx
+++ b/interface/src/components/AnalyzerCard.test.tsx
@@ -103,6 +103,50 @@ test('renders AERIS dashboard above technology chips after analysis', async () =
   expect(screen.queryByText(/Analysis Result/i)).not.toBeInTheDocument()
 })
 
+test('normalizes URL without scheme before fetching AERIS', async () => {
+  const { fetchAeris } = await import('../api')
+  vi.mocked(fetchAeris).mockClear()
+  const { default: AnalyzerCard } = await import('./AnalyzerCard')
+  const onAnalyze = vi.fn().mockResolvedValue(null)
+  const setUrl = vi.fn()
+  const { rerender } = render(
+    <AnalyzerCard
+      id="a"
+      url="example.com"
+      setUrl={setUrl}
+      onAnalyze={onAnalyze}
+      headless={false}
+      setHeadless={() => {}}
+      force={false}
+      setForce={() => {}}
+      loading={false}
+      error=""
+      result={null}
+    />,
+  )
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /analyze/i }))
+    await onAnalyze.mock.results[0].value
+  })
+  rerender(
+    <AnalyzerCard
+      id="a"
+      url="example.com"
+      setUrl={setUrl}
+      onAnalyze={onAnalyze}
+      headless={false}
+      setHeadless={() => {}}
+      force={false}
+      setForce={() => {}}
+      loading={false}
+      error=""
+      result={result}
+    />,
+  )
+  expect(await screen.findByText('AERIS Score')).toBeInTheDocument()
+  expect(fetchAeris).toHaveBeenCalledWith('https://example.com')
+})
+
 test('shows degraded banner', async () => {
   const { default: AnalyzerCard } = await import('./AnalyzerCard')
   render(

--- a/interface/src/components/AnalyzerCard.tsx
+++ b/interface/src/components/AnalyzerCard.tsx
@@ -6,6 +6,7 @@ import AerisDashboard from './aeris/AerisDashboard'
 import catalog from '../data/martech_catalog.json'
 import type { Snapshot } from '../types/snapshot'
 import { fetchAeris, type AerisResponse } from '../api'
+import { normalizeUrl } from '../utils'
 
 const vendorToCategory: Record<string, string> = {}
 for (const [cat, info] of Object.entries(catalog)) {
@@ -73,8 +74,10 @@ export default function AnalyzerCard({
 
   async function handleAnalyze() {
     setAeris(null)
+    const clean = normalizeUrl(url)
+    setUrl(clean)
     await onAnalyze()
-    fetchAeris(url)
+    fetchAeris(clean)
       .then((score) => setAeris(score))
       .catch(() => setAeris(null))
   }


### PR DESCRIPTION
## Summary
- Normalize URLs in AnalyzerCard before fetching AERIS and update state with cleaned value
- Add regression test ensuring URLs without scheme still load the AERIS dashboard

## Testing
- `npm test`
- `npx vitest run src/components/AnalyzerCard.test.tsx --reporter verbose`

------
https://chatgpt.com/codex/tasks/task_e_6896a10051fc832999dfc4c962ca9041