### PR TITLE
Configure AERIS model for insight service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       - PORT=8000
       - UI_ORIGIN=${UI_ORIGIN:-http://localhost:5173}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OPENAI_AERIS_MODEL=gpt-4o-mini
     ports:
       - "8083:8000"
 


### PR DESCRIPTION
## Summary
- set `OPENAI_AERIS_MODEL` to `gpt-4o-mini` for the insight service

## Testing
- `PYTHONPATH=/tmp OPENAI_AERIS_MODEL=gpt-4o-mini OPENAI_API_KEY=dummy python - <<'PY'
import json
from fastapi.testclient import TestClient
from services.insight.app import app, orchestrator

async def fake_call(messages, **kwargs):
    return (
        json.dumps({
            "core_score": 1,
            "signal_breakdown": [],
            "peers": [],
            "variants": [],
            "opportunities": [],
            "narratives": []
        }),
        "stop",
        False,
    )

orchestrator.call_openai_with_retry = fake_call

client = TestClient(app)
res = client.post("/aeris", json={"url": "https://example.com", "notes": "hi"})
print(res.status_code)
print(res.json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6896c0ef8f2883298dfeb0505d7902ce